### PR TITLE
Async file loading via IoCmdList and IoCmdQueue

### DIFF
--- a/game/src/game/game.cpp
+++ b/game/src/game/game.cpp
@@ -16,6 +16,10 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System.hpp>
 
+#include <heart/io/io_cmd_list.h>
+#include <heart/io/io_cmd_queue.h>
+#include <heart/sync/fence.h>
+
 #include <entt/entt.hpp>
 
 enum InputKey
@@ -77,17 +81,93 @@ void InitializeGame()
 {
 	s_registry.on_destroy<DrawableComponent>().connect<&DrawableComponent::OnDestroy>();
 
-	// Create our player
 	{
-		HeartDeserializeObjectFromFile(s_playerVals, "json/player_constants.json");
+		IoCmdQueue queue;
+		HeartFence fence;
+		IoCmdList cmdList;
 
-		auto player = create_multi_component<PlayerTag, InputStatusComponent, TransformComponent, DrawableComponent>();
-		auto& drawable = hrt::get<4>(player);
+		uint64_t size = 0;
 
-		drawable.texture = new sf::Texture();
-		HEART_CHECK(RenderUtils::LoadTextureFromFile(*drawable.texture, s_playerVals.texture.c_str()));
+		// Load the player constants
+		HeartGetFileSize("json/player_constants.json", size);
+		hrt::vector<uint8_t> playerConstantsBuffer(size, 0);
+		cmdList.BindIoFileDescriptor("json/player_constants.json");
+		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer {playerConstantsBuffer.data(), playerConstantsBuffer.size()});
+		cmdList.ReadEntire();
+		cmdList.Signal(&fence, 1);
 
-		drawable.sprite = new sf::Sprite(*drawable.texture);
+		// Load the background image
+		HeartGetFileSize("textures/bg.png", size);
+		hrt::vector<uint8_t> bgTextureBuffer(size, 0);
+		cmdList.BindIoFileDescriptor("textures/bg.png");
+		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer { bgTextureBuffer.data(), bgTextureBuffer.size() });
+		cmdList.ReadEntire();
+		cmdList.Signal(&fence, 2);
+
+		// Load the tileset data (not actually used, just a test)
+		HeartGetFileSize("json/tileset_list.json", size);
+		hrt::vector<uint8_t> tilesetBuffer(size, 0);
+		cmdList.BindIoFileDescriptor("json/tileset_list.json");
+		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer {tilesetBuffer.data(), tilesetBuffer.size() });
+		cmdList.ReadEntire();
+		cmdList.Signal(&fence, 3);
+
+		// Start loads
+		queue.Submit(&cmdList);
+
+		// Wait for the player constants
+		fence.Wait(1);
+
+		hrt::vector<uint8_t> playerTextureBuffer;
+		{
+			// Parse the constants
+			rapidjson::Document jsonDoc;
+			jsonDoc.Parse((const char*)playerConstantsBuffer.data(), playerConstantsBuffer.size());
+			if (!jsonDoc.HasParseError())
+			{
+				HeartDeserializeObject(s_playerVals, jsonDoc);
+
+				if (HeartGetFileSize(s_playerVals.texture.c_str(), size) && size)
+				{
+					playerTextureBuffer.resize(size);
+					cmdList.BindIoFileDescriptor(s_playerVals.texture.c_str());
+					cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer {playerTextureBuffer.data(), playerTextureBuffer.size()});
+					cmdList.ReadEntire();
+					cmdList.Signal(&fence, 4);
+					queue.Submit(&cmdList);
+				}
+			}
+		}
+
+		// Create the background
+		fence.Wait(2);
+		{
+			auto bg = create_multi_component<TransformComponent, DrawableComponent>();
+			auto& drawable = hrt::get<2>(bg);
+
+			drawable.texture = new sf::Texture();
+			drawable.texture->loadFromMemory(bgTextureBuffer.data(), bgTextureBuffer.size());
+
+			drawable.sprite = new sf::Sprite(*drawable.texture);
+			drawable.z = -10.0f;
+
+			auto& tf = hrt::get<1>(bg);
+			tf.position = sf::Vector2f(0.0f, -250.0f);
+		}
+
+		// Wait for the player texture if it existed, then create the player
+		if (!playerTextureBuffer.empty())
+		{
+			fence.Wait(4);
+
+			auto player = create_multi_component<PlayerTag, InputStatusComponent, TransformComponent, DrawableComponent>();
+			auto& drawable = hrt::get<4>(player);
+
+			drawable.texture = new sf::Texture();
+			drawable.texture->loadFromMemory(playerTextureBuffer.data(), playerTextureBuffer.size());
+
+			drawable.sprite = new sf::Sprite(*drawable.texture);
+		}
 	}
 
 	// Create our origin marker
@@ -103,21 +183,6 @@ void InitializeGame()
 
 		auto rect = new sf::Sprite(*drawable.texture);
 		drawable.sprite = rect;
-	}
-
-	// Create the background
-	{
-		auto bg = create_multi_component<TransformComponent, DrawableComponent>();
-		auto& drawable = hrt::get<2>(bg);
-
-		drawable.texture = new sf::Texture();
-		HEART_CHECK(RenderUtils::LoadTextureFromFile(*drawable.texture, "textures/bg.png"));
-
-		drawable.sprite = new sf::Sprite(*drawable.texture);
-		drawable.z = -10.0f;
-
-		auto& tf = hrt::get<1>(bg);
-		tf.position = sf::Vector2f(0.0f, -250.0f);
 	}
 
 	// Load and create a UI button

--- a/game/src/game/game.cpp
+++ b/game/src/game/game.cpp
@@ -100,7 +100,7 @@ void InitializeGame()
 		HeartGetFileSize("textures/bg.png", size);
 		hrt::vector<uint8_t> bgTextureBuffer(size, 0);
 		cmdList.BindIoFileDescriptor("textures/bg.png");
-		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer { bgTextureBuffer.data(), bgTextureBuffer.size() });
+		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer {bgTextureBuffer.data(), bgTextureBuffer.size()});
 		cmdList.ReadEntire();
 		cmdList.Signal(&fence, 2);
 
@@ -108,7 +108,7 @@ void InitializeGame()
 		HeartGetFileSize("json/tileset_list.json", size);
 		hrt::vector<uint8_t> tilesetBuffer(size, 0);
 		cmdList.BindIoFileDescriptor("json/tileset_list.json");
-		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer {tilesetBuffer.data(), tilesetBuffer.size() });
+		cmdList.BindIoTargetBuffer(IoCheckedTargetBuffer {tilesetBuffer.data(), tilesetBuffer.size()});
 		cmdList.ReadEntire();
 		cmdList.Signal(&fence, 3);
 

--- a/heart/heart-core/include/heart/file.h
+++ b/heart/heart-core/include/heart/file.h
@@ -30,6 +30,8 @@ bool HeartCloseFile(HeartFile& file);
 
 bool HeartGetFileSize(HeartFile& file, uint64_t& outSize);
 
+bool HeartGetFileSize(const char* path, uint64_t& outSize);
+
 bool HeartGetFileOffset(HeartFile& file, uint64_t& outOffset);
 
 bool HeartSetFileOffset(HeartFile& file, int64_t offset, uint64_t* newOffset = nullptr, HeartSetOffsetMode mode = HeartSetOffsetMode::Beginning);

--- a/heart/heart-core/include/heart/file.h
+++ b/heart/heart-core/include/heart/file.h
@@ -32,7 +32,7 @@ bool HeartGetFileSize(HeartFile& file, uint64_t& outSize);
 
 bool HeartGetFileOffset(HeartFile& file, uint64_t& outOffset);
 
-bool HeartSetFileOffset(HeartFile& file, uint64_t offset, uint64_t* newOffset = nullptr, HeartSetOffsetMode mode = HeartSetOffsetMode::Beginning);
+bool HeartSetFileOffset(HeartFile& file, int64_t offset, uint64_t* newOffset = nullptr, HeartSetOffsetMode mode = HeartSetOffsetMode::Beginning);
 
 bool HeartReadFile(HeartFile& file, byte_t* buffer, size_t size, size_t bytesToRead, size_t* bytesRead = nullptr);
 
@@ -53,6 +53,11 @@ bool HeartWriteFile(HeartFile& file, byte_t (&buffer)[N], size_t* bytesWritten =
 struct HeartFile
 {
 	uintptr_t nativeHandle = 0;
+
+	explicit operator bool() const
+	{
+		return nativeHandle != 0;
+	}
 
 	~HeartFile()
 	{

--- a/heart/heart-core/include/heart/io/io_cmd_list.h
+++ b/heart/heart-core/include/heart/io/io_cmd_list.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <heart/io/io_forward_decl.h>
+
+class HeartFence;
+
+enum class IoFileMode
+{
+	Read,
+	Write,
+};
+
+class IoFileDescriptor
+{
+public:
+	IoFileDescriptor(const char* f);
+	IoFileDescriptor(const char* f, size_t l);
+
+	const char* GetFilename()
+	{
+		return m_filename;
+	}
+
+private:
+	static_assert(MaxFilePath < 255, "Cannot fit MaxFilePath size in uint8!");
+
+	uint8_t m_size;
+	char m_filename[MaxFilePath];
+};
+
+struct IoUncheckedTargetBuffer
+{
+	void* ptr;
+};
+
+struct IoCheckedTargetBuffer
+{
+	void* ptr;
+	size_t size;
+};
+
+enum class IoOffsetType : uint8_t
+{
+	FromStart,
+	FromCurrent,
+	FromEnd,
+};
+
+class IoCmdList
+{
+public:
+	void BindIoFileDescriptor(const IoFileDescriptor& d);
+
+	void BindIoTargetBuffer(const IoUncheckedTargetBuffer& b);
+	void BindIoTargetBuffer(const IoCheckedTargetBuffer& b);
+
+	void ReadEntire();
+	void ReadPartial(size_t readLength);
+
+	void Offset(int64_t offset, IoOffsetType type);
+
+	void UnbindFileDescriptor();
+	void UnbindTargetBuffer();
+
+	void Signal(HeartFence* fence, uint32_t value);
+	void Wait(HeartFence* fence, uint32_t value);
+
+	void Reset();
+
+private:
+	uint16_t m_writeHead = 0;
+	uint8_t m_cmdPool[8ull * Kilo];
+
+	void Finalize();
+};

--- a/heart/heart-core/include/heart/io/io_cmd_list.h
+++ b/heart/heart-core/include/heart/io/io_cmd_list.h
@@ -16,9 +16,14 @@ public:
 	IoFileDescriptor(const char* f);
 	IoFileDescriptor(const char* f, size_t l);
 
-	const char* GetFilename()
+	const char* GetFilename() const
 	{
 		return m_filename;
+	}
+
+	uint8_t GetSize() const
+	{
+		return m_size;
 	}
 
 private:
@@ -48,6 +53,8 @@ enum class IoOffsetType : uint8_t
 
 class IoCmdList
 {
+	friend class IoCmdQueue;
+
 public:
 	void BindIoFileDescriptor(const IoFileDescriptor& d);
 

--- a/heart/heart-core/include/heart/io/io_cmd_queue.h
+++ b/heart/heart-core/include/heart/io/io_cmd_queue.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <heart/io/io_forward_decl.h>
+
+class IoCmdQueue
+{
+	void Submit(IoCmdList* cmdList);
+};

--- a/heart/heart-core/include/heart/io/io_cmd_queue.h
+++ b/heart/heart-core/include/heart/io/io_cmd_queue.h
@@ -2,7 +2,45 @@
 
 #include <heart/io/io_forward_decl.h>
 
+#include <heart/sync/condition_variable.h>
+#include <heart/sync/mutex.h>
+#include <heart/thread.h>
+
+#include <heart/stl/vector.h>
+
+#include <atomic>
+
 class IoCmdQueue
 {
+public:
+	IoCmdQueue(int threadCount = 1);
+	~IoCmdQueue();
+
 	void Submit(IoCmdList* cmdList);
+	void Flush();
+	void Close();
+
+private:
+	hrt::vector<HeartThread> m_threads;
+	HeartMutex m_mutex;
+	HeartConditionVariable m_cv;
+
+	static void* ThreadEntryPoint(void*);
+
+	void ThreadThink();
+
+	std::atomic_bool m_threadExit = false;
+
+	struct CmdPage
+	{
+		CmdPage* next = nullptr;
+		uint16_t size = 0;
+		uint16_t inUse = 0;
+		uint8_t data[8ull * Kilo];
+	};
+
+	CmdPage m_pages[16] = {};
+	CmdPage* m_head = nullptr;
+
+	void ProcessCmdPage(CmdPage& page);
 };

--- a/heart/heart-core/include/heart/io/io_forward_decl.h
+++ b/heart/heart-core/include/heart/io/io_forward_decl.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <heart/types.h>
+
+static constexpr size_t MaxFilePath = 127;
+
+class IoFileDescriptor;
+class IoCmdList;
+class IoCmdPool;
+
+struct IoUncheckedTargetBuffer;
+struct IoCheckedTargetBuffer;
+
+enum class IoOffsetType : uint8_t;

--- a/heart/heart-core/include/heart/io/io_op_type.h
+++ b/heart/heart-core/include/heart/io/io_op_type.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <heart/types.h>
+
+enum class IoOpType : uint16_t
+{
+	BindDescriptor,
+	BindBufferUnchecked,
+	BindBufferChecked,
+	ReadEntire,
+	ReadPartial,
+	Offset,
+	UnbindDescriptor,
+	UnbindTarget,
+	Reset,
+	SignalFence,
+	WaitForFence,
+};

--- a/heart/heart-core/include/heart/stream.h
+++ b/heart/heart-core/include/heart/stream.h
@@ -60,13 +60,13 @@ public:
 		if (!Check(sizeof(v) * count))
 			return false;
 
-		memcpy(m_buffer + *m_head, v, sizeof(v) * count);
-		*m_head += BufferSizeT(sizeof(v) * count);
+		memcpy(m_buffer + *m_head, v, sizeof(T) * count);
+		*m_head += BufferSizeT(sizeof(T) * count);
 		return true;
 	}
 };
 
-template <typename BufferSizeT>
+template <typename BufferSizeT = size_t>
 class HeartStreamReader
 {
 	const uint8_t* m_buffer;
@@ -120,6 +120,15 @@ public:
 	{
 		const T* h = reinterpret_cast<const T*>(m_buffer + *m_head);
 		*m_head += BufferSizeT(sizeof(T));
+
+		return h;
+	}
+
+	template <typename T>
+	const T* ReadSpan(BufferSizeT count)
+	{
+		const T* h = reinterpret_cast<const T*>(m_buffer + *m_head);
+		*m_head += BufferSizeT(sizeof(T) * count);
 
 		return h;
 	}

--- a/heart/heart-core/include/heart/sync/fence.h
+++ b/heart/heart-core/include/heart/sync/fence.h
@@ -18,4 +18,6 @@ public:
 
 	void Signal(uint32_t revision);
 	void Wait(uint32_t revision);
+
+	bool Test(uint32_t revision);
 };

--- a/heart/heart-core/include/heart/thread.h
+++ b/heart/heart-core/include/heart/thread.h
@@ -34,4 +34,27 @@ public:
 
 	void Join();
 	void Detach();
+	void SetName(const char* name);
+
+	explicit operator bool() const;
+
+	friend bool operator==(decltype(nullptr), const HeartThread& t)
+	{
+		return !t;
+	}
+
+	friend bool operator==(const HeartThread& t, decltype(nullptr))
+	{
+		return !t;
+	}
+
+	friend bool operator!=(decltype(nullptr), const HeartThread& t)
+	{
+		return !!t;
+	}
+
+	friend bool operator!=(const HeartThread& t, decltype(nullptr))
+	{
+		return !!t;
+	}
 };

--- a/heart/heart-core/src/file.cpp
+++ b/heart/heart-core/src/file.cpp
@@ -115,6 +115,31 @@ bool HeartGetFileSize(HeartFile& file, uint64_t& outSize)
 	return true;
 }
 
+bool HeartGetFileSize(const char* path, uint64_t& outSize)
+{
+	outSize = 0;
+
+	wchar_t filePath[MAX_PATH];
+	int written = swprintf_s(filePath, L"%s", s_fileRoot);
+	if (written < 0)
+		return false;
+
+	written = swprintf_s(filePath + written, MAX_PATH - written, L"%S", path);
+	if (written <= 0)
+		return false;
+
+	LARGE_INTEGER size = {};
+	WIN32_FILE_ATTRIBUTE_DATA resultData = {};
+	if (!::GetFileAttributesEx(filePath, GetFileExInfoStandard, &resultData))
+		return false;
+
+	size.LowPart = resultData.nFileSizeLow;
+	size.HighPart = resultData.nFileSizeHigh;
+
+	outSize = size.QuadPart;
+	return true;
+}
+
 bool HeartGetFileOffset(HeartFile& file, uint64_t& outOffset)
 {
 	outOffset = 0;

--- a/heart/heart-core/src/file.cpp
+++ b/heart/heart-core/src/file.cpp
@@ -132,7 +132,7 @@ bool HeartGetFileOffset(HeartFile& file, uint64_t& outOffset)
 	return true;
 }
 
-bool HeartSetFileOffset(HeartFile& file, uint64_t offset, uint64_t* newOffset, HeartSetOffsetMode mode)
+bool HeartSetFileOffset(HeartFile& file, int64_t offset, uint64_t* newOffset, HeartSetOffsetMode mode)
 {
 	if (file.nativeHandle == 0)
 		return false;

--- a/heart/heart-core/src/io/io_cmd_list.cpp
+++ b/heart/heart-core/src/io/io_cmd_list.cpp
@@ -26,7 +26,8 @@ void IoCmdList::BindIoFileDescriptor(const IoFileDescriptor& d)
 	HeartStreamWriter writer(m_cmdPool, m_writeHead);
 
 	HEART_CHECK(writer.Write(IoOpType::BindDescriptor));
-	HEART_CHECK(writer.Write(d));
+	HEART_CHECK(writer.Write(d.GetSize()));
+	HEART_CHECK(writer.Write(d.GetFilename(), d.GetSize()));
 }
 
 void IoCmdList::BindIoTargetBuffer(const IoUncheckedTargetBuffer& b)

--- a/heart/heart-core/src/io/io_cmd_list.cpp
+++ b/heart/heart-core/src/io/io_cmd_list.cpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <heart/io/io_cmd_list.h>
+#include <heart/io/io_op_type.h>
+
+#include <heart/debug/assert.h>
+
+#include <heart/config.h>
+#include <heart/countof.h>
+#include <heart/stream.h>
+
+IoFileDescriptor::IoFileDescriptor(const char* f) :
+	IoFileDescriptor(f, strlen(f))
+{
+}
+
+IoFileDescriptor::IoFileDescriptor(const char* f, size_t l) :
+	m_size(uint8_t(l))
+{
+	HEART_ASSERT(strlen(f) == m_size);
+	memcpy(m_filename, f, l);
+}
+
+void IoCmdList::BindIoFileDescriptor(const IoFileDescriptor& d)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::BindDescriptor));
+	HEART_CHECK(writer.Write(d));
+}
+
+void IoCmdList::BindIoTargetBuffer(const IoUncheckedTargetBuffer& b)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::BindBufferUnchecked));
+	HEART_CHECK(writer.Write(b));
+}
+
+void IoCmdList::BindIoTargetBuffer(const IoCheckedTargetBuffer& b)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+#if !HEART_STRICT_PERF
+	HEART_CHECK(writer.Write(IoOpType::BindBufferChecked));
+	HEART_CHECK(writer.Write(b));
+#else
+	IoUncheckedTargetBuffer unchecked = {b.ptr};
+	HEART_CHECK(writer.Write(IoOpType::BindBufferUnchecked));
+	HEART_CHECK(writer.Write(unchecked));
+#endif
+}
+
+void IoCmdList::ReadEntire()
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::ReadEntire));
+}
+
+void IoCmdList::ReadPartial(size_t readLength)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::ReadPartial));
+	HEART_CHECK(writer.Write(readLength));
+}
+
+void IoCmdList::Offset(int64_t offset, IoOffsetType type)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::Offset));
+	HEART_CHECK(writer.Write(offset));
+	HEART_CHECK(writer.Write(type));
+}
+
+void IoCmdList::UnbindFileDescriptor()
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::UnbindDescriptor));
+}
+
+void IoCmdList::UnbindTargetBuffer()
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::UnbindTarget));
+}
+
+void IoCmdList::Signal(HeartFence* fence, uint32_t value)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::SignalFence));
+	HEART_CHECK(writer.Write(fence));
+	HEART_CHECK(writer.Write(value));
+}
+
+void IoCmdList::Wait(HeartFence* fence, uint32_t value)
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::WaitForFence));
+	HEART_CHECK(writer.Write(fence));
+	HEART_CHECK(writer.Write(value));
+}
+
+void IoCmdList::Reset()
+{
+	HeartStreamWriter writer(m_cmdPool, m_writeHead);
+
+	HEART_CHECK(writer.Write(IoOpType::Reset));
+}
+
+void IoCmdList::Finalize()
+{
+	m_writeHead = 0;
+}

--- a/heart/heart-core/src/io/io_cmd_queue.cpp
+++ b/heart/heart-core/src/io/io_cmd_queue.cpp
@@ -1,0 +1,262 @@
+#include "heart/io/io_cmd_queue.h"
+#include "heart/io/io_cmd_list.h"
+#include "heart/io/io_op_type.h"
+
+#include "heart/countof.h"
+#include "heart/file.h"
+#include "heart/stream.h"
+
+#include "heart/sync/fence.h"
+
+#include <algorithm>
+#include <iterator>
+
+#define NOMINMAX 1
+#define WIN32_LEAN_AND_MEAN 1
+#include <Windows.h>
+
+IoCmdQueue::IoCmdQueue(int threadCount)
+{
+	threadCount = std::max(threadCount, 1);
+	std::generate_n(std::back_inserter(m_threads), threadCount, [this]() {
+		HeartThread t(&ThreadEntryPoint, this);
+		t.SetName("IoCmdQueue Thread");
+		return hrt::move(t);
+	});
+}
+
+IoCmdQueue::~IoCmdQueue()
+{
+	Close();
+}
+
+void IoCmdQueue::Flush()
+{
+	HeartUniqueLock lock(m_mutex);
+
+	while (std::any_of(std::begin(m_pages), std::end(m_pages), [](const CmdPage& page) { return page.inUse; }))
+	{
+		lock.Unlock();
+		Sleep(0);
+		lock.Lock();
+	}
+}
+
+void IoCmdQueue::Close()
+{
+	if (!m_threads.empty())
+	{
+		Flush();
+
+		m_threadExit = true;
+		m_cv.NotifyAll();
+
+		for (auto& t : m_threads)
+			t.Join();
+
+		m_threads.clear();
+	}
+}
+
+void IoCmdQueue::Submit(IoCmdList* cmdList)
+{
+	{
+		HeartLockGuard lock(m_mutex);
+
+		// Find a free page
+		CmdPage* tgtPage = nullptr;
+		for (auto& p : m_pages)
+		{
+			if (!p.inUse)
+			{
+				tgtPage = &p;
+				break;
+			}
+		}
+
+		// Copy our data
+		tgtPage->size = cmdList->m_writeHead;
+		memcpy_s(tgtPage->data, HeartCountOf(tgtPage->data), cmdList->m_cmdPool, cmdList->m_writeHead);
+
+		// Point to the new page
+		CmdPage** tgt = &m_head;
+		while (*tgt != nullptr)
+		{
+			tgt = &(*tgt)->next;
+		}
+
+		*tgt = tgtPage;
+	}
+
+	// Reset the cmd list
+	cmdList->Finalize();
+
+	// Wake the thread
+	m_cv.NotifyOne();
+}
+
+void IoCmdQueue::ThreadThink()
+{
+	CmdPage* workingPage = nullptr;
+
+	while (true)
+	{
+		{
+			HeartLockGuard lock(m_mutex);
+
+			if (workingPage != nullptr)
+			{
+				workingPage->inUse = false;
+				workingPage = nullptr;
+			}
+
+			while (m_head == nullptr && m_threadExit.load(std::memory_order_relaxed) == false)
+			{
+				m_cv.Wait(m_mutex);
+			}
+
+			if (m_threadExit.load(std::memory_order_relaxed))
+				break;
+
+			workingPage = m_head;
+			m_head = workingPage->next;
+		}
+
+		ProcessCmdPage(*workingPage);
+	}
+}
+
+void IoCmdQueue::ProcessCmdPage(CmdPage& page)
+{
+	uint16_t readHead = 0;
+
+	struct IoState
+	{
+		// TODO: true async io
+		HeartFile currentFile = {};
+		const IoFileDescriptor* currentDescriptor = nullptr;
+		void* currentTargetBuffer = nullptr;
+		int64_t currentTargetBufferSize = -1;
+	} state;
+
+	HeartStreamReader reader(page.data, &readHead);
+	while (readHead < page.size)
+	{
+		IoOpType operation = reader.Read<IoOpType>(reader.Copy);
+
+		switch (operation)
+		{
+		case IoOpType::BindDescriptor: {
+			const IoFileDescriptor* d = reader.Read<IoFileDescriptor>(reader.GetPtr);
+			state.currentDescriptor = d;
+
+			if (state.currentFile)
+				HeartCloseFile(state.currentFile);
+
+			char path[MAX_PATH] = {};
+			strncpy_s(path, state.currentDescriptor->GetFilename(), state.currentDescriptor->GetSize());
+
+			HeartOpenFile(state.currentFile, path, HeartOpenFileMode::ReadExisting);
+
+			break;
+		}
+		case IoOpType::BindBufferUnchecked: {
+			IoUncheckedTargetBuffer buffer = reader.Read<IoUncheckedTargetBuffer>(reader.Copy);
+			state.currentTargetBuffer = buffer.ptr;
+			state.currentTargetBufferSize = -1;
+			break;
+		}
+		case IoOpType::BindBufferChecked: {
+			IoCheckedTargetBuffer buffer = reader.Read<IoCheckedTargetBuffer>(reader.Copy);
+			state.currentTargetBuffer = buffer.ptr;
+			state.currentTargetBufferSize = int64_t(buffer.size);
+			break;
+		}
+		case IoOpType::ReadEntire: {
+			HEART_ASSERT(state.currentDescriptor != nullptr);
+			HEART_ASSERT(state.currentTargetBuffer != nullptr);
+
+			if (state.currentFile)
+			{
+				uint64_t size = 0;
+				if (HeartGetFileSize(state.currentFile, size))
+				{
+					size_t bufferSize = state.currentTargetBufferSize < 0 ? size_t(size) : size_t(state.currentTargetBufferSize);
+					if (state.currentTargetBufferSize < 0 || int64_t(size) <= state.currentTargetBufferSize)
+					{
+						HeartReadFile(state.currentFile, (byte_t*)state.currentTargetBuffer, bufferSize, size);
+					}
+				}
+			}
+
+			break;
+		}
+		case IoOpType::ReadPartial: {
+			HEART_ASSERT(state.currentDescriptor != nullptr);
+			HEART_ASSERT(state.currentTargetBuffer != nullptr);
+
+			size_t toRead = reader.Read<size_t>(reader.Copy);
+
+			if (state.currentFile)
+			{
+				size_t bufferSize = state.currentTargetBufferSize < 0 ? toRead : size_t(state.currentTargetBufferSize);
+				HeartReadFile(state.currentFile, (byte_t*)state.currentTargetBuffer, bufferSize, toRead);
+			}
+
+			break;
+		}
+		case IoOpType::Offset: {
+			HEART_ASSERT(state.currentDescriptor != nullptr);
+
+			int64_t offset = reader.Read<int64_t>(reader.Copy);
+			IoOffsetType type = reader.Read<IoOffsetType>(reader.Copy);
+
+			if (state.currentFile)
+			{
+				HeartSetOffsetMode heartMode = HeartSetOffsetMode::Beginning;
+				switch (type)
+				{
+				case IoOffsetType::FromStart: heartMode = HeartSetOffsetMode::Beginning; break;
+				case IoOffsetType::FromCurrent: heartMode = HeartSetOffsetMode::Current; break;
+				case IoOffsetType::FromEnd: heartMode = HeartSetOffsetMode::End; break;
+				}
+
+				HeartSetFileOffset(state.currentFile, offset, nullptr, heartMode);
+			}
+
+			break;
+		}
+		case IoOpType::UnbindDescriptor: {
+			state.currentDescriptor = nullptr;
+			break;
+		}
+		case IoOpType::UnbindTarget: {
+			state.currentTargetBuffer = nullptr;
+			state.currentTargetBufferSize = -1;
+			break;
+		}
+		case IoOpType::Reset: {
+			break;
+		}
+		case IoOpType::SignalFence: {
+			HeartFence* fence = reader.Read<HeartFence*>(reader.Copy);
+			uint32_t value = reader.Read<uint32_t>(reader.Copy);
+			fence->Signal(value);
+			break;
+		}
+		case IoOpType::WaitForFence: {
+			HeartFence* fence = reader.Read<HeartFence*>(reader.Copy);
+			uint32_t value = reader.Read<uint32_t>(reader.Copy);
+			fence->Wait(value);
+			break;
+		}
+		}
+	}
+}
+
+void* IoCmdQueue::ThreadEntryPoint(void* p)
+{
+	IoCmdQueue* q = (IoCmdQueue*)p;
+	q->ThreadThink();
+	return nullptr;
+}

--- a/heart/heart-core/src/io/io_cmd_queue.cpp
+++ b/heart/heart-core/src/io/io_cmd_queue.cpp
@@ -156,7 +156,7 @@ void IoCmdQueue::ProcessCmdPage(CmdPage& page)
 				HeartCloseFile(state.currentFile);
 
 			char path[MAX_PATH] = {};
-			strncpy_s(path, pathStr,  pathSize);
+			strncpy_s(path, pathStr, pathSize);
 
 			HeartOpenFile(state.currentFile, path, HeartOpenFileMode::ReadExisting);
 

--- a/heart/heart-core/src/sync/sync.cpp
+++ b/heart/heart-core/src/sync/sync.cpp
@@ -114,3 +114,9 @@ void HeartFence::Wait(uint32_t revision)
 		m_cv.Wait(m_mutex);
 	}
 }
+
+bool HeartFence::Test(uint32_t revision)
+{
+	HeartLockGuard lock(m_mutex);
+	return m_currentRevision >= revision;
+}

--- a/heart/heart-core/src/thread.cpp
+++ b/heart/heart-core/src/thread.cpp
@@ -3,6 +3,7 @@
 #include <heart/debug/assert.h>
 
 #include <atomic>
+#include <malloc.h>
 
 #define NOMINMAX 1
 #define WIN32_LEAN_AND_MEAN 1
@@ -85,7 +86,10 @@ void HeartThread::Join()
 	HANDLE h = m_handle;
 	m_handle = nullptr;
 
-	WaitForSingleObject(h, INFINITE);
+	if (h)
+	{
+		WaitForSingleObject(h, INFINITE);
+	}
 }
 
 void HeartThread::Detach()
@@ -93,5 +97,21 @@ void HeartThread::Detach()
 	HANDLE h = m_handle;
 	m_handle = nullptr;
 
-	CloseHandle(h);
+	if (h)
+	{
+		CloseHandle(h);
+	}
+}
+
+void HeartThread::SetName(const char* name)
+{
+	auto wideLength = ::MultiByteToWideChar(0, 0, name, -1, NULL, 0);
+	wchar_t* buffer = (wchar_t*)_alloca(wideLength * sizeof(wchar_t));
+	::MultiByteToWideChar(0, 0, name, -1, buffer, wideLength);
+	::SetThreadDescription(HANDLE(m_handle), buffer);
+}
+
+HeartThread::operator bool() const
+{
+	return (m_handle != nullptr);
 }


### PR DESCRIPTION
File IO should be nonblocking wherever possible. Using graphics APIs as inspiration, adds an async io implementation that records file IO commands to a command list and then executes them on another thread when submitted to a command queue. The number of threads started by the queue is configurable. Submitted command lists may be executed in parallel with each other if enough threads are available, but individual commands on the list will be executed in the order in which they were recorded.