### PR TITLE
HeartIntrusivePtr

### DIFF
--- a/heart/heart-core/include/heart/memory/intrusive_ptr.h
+++ b/heart/heart-core/include/heart/memory/intrusive_ptr.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <heart/config.h>
+
+#include <heart/debug/assert.h>
+#include <heart/types.h>
+
+#include <heart/stl/move.h>
+
+#include <heart/util/canonical_typedefs.h>
+
+struct Example
+{
+	uint32_t refCount = 0;
+};
+
+template <typename T>
+void HeartIncrementRef(T* t)
+{
+	t->IncrementRef();
+}
+
+template <typename T>
+void HeartDecrementRef(T* t)
+{
+	t->DecrementRef();
+}
+
+template <typename T>
+uint32_t HeartGetRefCount(T* t)
+{
+	return t->GetRefCount();
+}
+
+template <typename T>
+class HeartIntrusivePtr
+{
+public:
+	DECLARE_STANDARD_TYPEDEFS(T);
+
+	HeartIntrusivePtr() = default;
+
+	HeartIntrusivePtr(decltype(nullptr)) noexcept :
+		HeartIntrusivePtr()
+	{
+	}
+
+	template <typename Y>
+	HeartIntrusivePtr(Y* ptr) noexcept :
+		HeartIntrusivePtr()
+	{
+		if (ptr)
+		{
+			_p = ptr;
+			HeartIncrementRef(_p);
+		}
+	}
+
+	HeartIntrusivePtr(HeartIntrusivePtr&& p) noexcept :
+		HeartIntrusivePtr()
+	{
+		p.Swap(*this);
+	}
+
+	HeartIntrusivePtr(const HeartIntrusivePtr& p) noexcept :
+		HeartIntrusivePtr()
+	{
+		HeartIntrusivePtr t(p.Get());
+		t.Swap(*this);
+	}
+
+	HeartIntrusivePtr& operator=(HeartIntrusivePtr&& p) noexcept
+	{
+		HeartIntrusivePtr(hrt::move(p)).Swap(*this);
+		return *this;
+	}
+
+	HeartIntrusivePtr& operator=(const HeartIntrusivePtr& p) noexcept
+	{
+		HeartIntrusivePtr(p).Swap(*this);
+		return *this;
+	}
+
+	~HeartIntrusivePtr() noexcept
+	{
+		Reset();
+	}
+
+	void Reset() noexcept
+	{
+		if (_p)
+		{
+			HeartDecrementRef(_p);
+			_p = nullptr;
+		}
+	}
+
+	void Swap(HeartIntrusivePtr& p) noexcept
+	{
+		pointer t = p.Get();
+		p._p = Get();
+		_p = t;
+	}
+
+	pointer Get() const
+	{
+		return _p;
+	}
+
+	pointer operator->() const
+	{
+		return _p;
+	}
+
+	reference operator*() const
+	{
+		HEART_ASSERT(_p);
+		return *_p;
+	}
+
+	uint32_t UseCount() const
+	{
+		if (!_p)
+			return 0;
+
+		return HeartGetRefCount(_p);
+	}
+
+	explicit operator bool() const noexcept
+	{
+		return _p != nullptr;
+	}
+
+	template <typename U>
+	friend bool operator==(const HeartIntrusivePtr& lhs, const HeartIntrusivePtr<U>& rhs) noexcept
+	{
+		return lhs.Get() == rhs.Get();
+	}
+
+	template <typename U>
+	friend auto operator<=>(const HeartIntrusivePtr& lhs, const HeartIntrusivePtr<U>& rhs) noexcept
+	{
+		return lhs.Get() <=> rhs.Get();
+	}
+
+	friend bool operator==(const HeartIntrusivePtr& lhs, decltype(nullptr)) noexcept
+	{
+		return lhs.Get() == nullptr;
+	}
+
+	friend auto operator<=>(const HeartIntrusivePtr& lhs, decltype(nullptr)) noexcept
+	{
+		return lhs.Get() <=> nullptr;
+	}
+
+private:
+	pointer _p = nullptr;
+};

--- a/heart/heart-test/src/intrusive_ptr.cpp
+++ b/heart/heart-test/src/intrusive_ptr.cpp
@@ -1,0 +1,243 @@
+#include <heart/memory/intrusive_ptr.h>
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+struct RefCountedType
+{
+	uint32_t refCount = 0;
+};
+
+void HeartIncrementRef(RefCountedType* p)
+{
+	++p->refCount;
+}
+
+void HeartDecrementRef(RefCountedType* p)
+{
+	--p->refCount;
+}
+
+uint32_t HeartGetRefCount(RefCountedType* p)
+{
+	return p->refCount;
+}
+
+TEST(HeartIntrusivePtr, OverloadedRefCounting)
+{
+	RefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+	EXPECT_EQ(&refCounter, p.Get());
+	EXPECT_EQ(p->refCount, refCounter.refCount);
+	EXPECT_EQ((*p).refCount, refCounter.refCount);
+	EXPECT_EQ(p.UseCount(), refCounter.refCount);
+	EXPECT_TRUE(p);
+	EXPECT_TRUE(p != nullptr);
+	EXPECT_TRUE(nullptr != p);
+	EXPECT_FALSE(!p);
+	EXPECT_FALSE(p == nullptr);
+	EXPECT_FALSE(nullptr == p);
+
+	p = nullptr;
+	EXPECT_EQ(refCounter.refCount, 0);
+	EXPECT_TRUE(!p);
+	EXPECT_TRUE(p == nullptr);
+	EXPECT_TRUE(nullptr == p);
+	EXPECT_FALSE(p);
+	EXPECT_FALSE(p != nullptr);
+	EXPECT_FALSE(nullptr != p);
+
+	p = &refCounter;
+	EXPECT_EQ(refCounter.refCount, 1);
+}
+
+TEST(HeartIntrusivePtr, Reset)
+{
+	RefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+
+	p.Reset();
+	EXPECT_EQ(refCounter.refCount, 0);
+}
+
+TEST(HeartIntrusivePtr, Swap)
+{
+	RefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+
+	HeartIntrusivePtr<RefCountedType> q;
+
+	p.Swap(q);
+	EXPECT_EQ(refCounter.refCount, 1);
+	EXPECT_FALSE(p);
+	EXPECT_TRUE(q);
+}
+
+TEST(HeartIntrusivePtr, CopyConstructor)
+{
+	RefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+
+	HeartIntrusivePtr<RefCountedType> q(p);
+	EXPECT_EQ(refCounter.refCount, 2);
+	EXPECT_TRUE(p);
+	EXPECT_TRUE(q);
+}
+
+TEST(HeartIntrusivePtr, CopyAssignment)
+{
+	RefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+
+	HeartIntrusivePtr<RefCountedType> q = p;
+	EXPECT_EQ(refCounter.refCount, 2);
+	EXPECT_TRUE(p);
+	EXPECT_TRUE(q);
+}
+
+TEST(HeartIntrusivePtr, MoveConstructor)
+{
+	RefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+
+	HeartIntrusivePtr<RefCountedType> q(std::move(p));
+	EXPECT_EQ(refCounter.refCount, 1);
+	EXPECT_FALSE(p);
+	EXPECT_TRUE(q);
+}
+
+TEST(HeartIntrusivePtr, MoveAssignment)
+{
+	RefCountedType refCounter1;
+	EXPECT_EQ(refCounter1.refCount, 0);
+
+	RefCountedType refCounter2;
+	EXPECT_EQ(refCounter2.refCount, 0);
+
+	HeartIntrusivePtr<RefCountedType> p(&refCounter1);
+	EXPECT_EQ(refCounter1.refCount, 1);
+
+	HeartIntrusivePtr<RefCountedType> q(&refCounter2);
+	EXPECT_EQ(refCounter2.refCount, 1);
+
+	q = std::move(p);
+	EXPECT_EQ(refCounter2.refCount, 0);
+	EXPECT_EQ(refCounter1.refCount, 1);
+	EXPECT_FALSE(p);
+	EXPECT_TRUE(q);
+}
+
+struct ComplexRefCountedType
+{
+	uint32_t refCount = 0;
+
+	void IncrementRef()
+	{
+		++refCount;
+	}
+
+	void DecrementRef()
+	{
+		--refCount;
+	}
+
+	uint32_t GetRefCount() const
+	{
+		return refCount;
+	}
+};
+
+TEST(HeartIntrusivePtr, TemplateRefCounting)
+{
+	ComplexRefCountedType refCounter;
+	EXPECT_EQ(refCounter.refCount, 0);
+
+	HeartIntrusivePtr<ComplexRefCountedType> p(&refCounter);
+	EXPECT_EQ(refCounter.refCount, 1);
+	EXPECT_EQ(&refCounter, p.Get());
+	EXPECT_EQ(p->refCount, refCounter.refCount);
+	EXPECT_EQ((*p).refCount, refCounter.refCount);
+	EXPECT_EQ(p.UseCount(), refCounter.refCount);
+	EXPECT_TRUE(p);
+	EXPECT_TRUE(p != nullptr);
+	EXPECT_TRUE(nullptr != p);
+	EXPECT_FALSE(!p);
+	EXPECT_FALSE(p == nullptr);
+	EXPECT_FALSE(nullptr == p);
+
+	p = nullptr;
+	EXPECT_EQ(refCounter.refCount, 0);
+	EXPECT_TRUE(!p);
+	EXPECT_TRUE(p == nullptr);
+	EXPECT_TRUE(nullptr == p);
+	EXPECT_FALSE(p);
+	EXPECT_FALSE(p != nullptr);
+	EXPECT_FALSE(nullptr != p);
+
+	p = &refCounter;
+	EXPECT_EQ(refCounter.refCount, 1);
+}
+
+static bool MemoryManagedTypeDestroyed = false;
+
+struct MemoryManagedType
+{
+	~MemoryManagedType()
+	{
+		MemoryManagedTypeDestroyed = true;
+	}
+
+	uint32_t refCount = 0;
+};
+
+void HeartIncrementRef(MemoryManagedType* p)
+{
+	++p->refCount;
+}
+
+void HeartDecrementRef(MemoryManagedType* p)
+{
+	if (--p->refCount == 0)
+	{
+		delete p;
+	}
+}
+
+uint32_t HeartGetRefCount(MemoryManagedType* p)
+{
+	return p->refCount;
+}
+
+TEST(HeartIntrusivePtr, RealMemoryManagement)
+{
+	HeartIntrusivePtr<MemoryManagedType> p = new MemoryManagedType();
+	EXPECT_TRUE(p);
+	EXPECT_EQ(p->refCount, 1);
+	EXPECT_EQ(p.UseCount(), 1);
+	EXPECT_FALSE(MemoryManagedTypeDestroyed);
+
+	p = nullptr;
+	EXPECT_FALSE(p);
+	EXPECT_EQ(p.Get(), nullptr);
+	EXPECT_EQ(p.UseCount(), 0);
+	EXPECT_TRUE(MemoryManagedTypeDestroyed);
+}


### PR DESCRIPTION
Allows refcounting without having to allocate a separate manager.

Does not support weak references.