### PR TITLE
Add HeartFiberSystem which is better than HeartJobSystem in nearly every way

### DIFF
--- a/heart/heart-core/include/heart/fibers/context.h
+++ b/heart/heart-core/include/heart/fibers/context.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <heart/fibers/fwd.h>
+
+#include <heart/fibers/work_unit.h>
+
+class HeartFiberContext
+{
+private:
+	friend class HeartFiberSystem;
+
+	// The system that is executing the current thread. If we're on
+	// a fiber, should *never* be null.
+	HeartFiberSystem* currentSystem;
+
+	// The pump for the current thread. If we're on a fiber, should always be valid
+	// until the thread exits. The pump executes HeartFiberSystem::PumpRoutine
+	HeartFiberWorkUnit pump;
+
+	// The currently executing work unit. If we're on a fiber, should
+	// never be null after the first switch to the pump
+	HeartFiberWorkUnit* currentWorkUnit;
+
+	// The destroy queue for this thread. Only work units which have completed
+	// on this thread can be destroyed by this thread. This prevents a race
+	// condition where the pump running on one thread could kill a currently
+	// executing fiber on another thread before it jumps, causing a crash.
+	HeartFiberWorkUnit::Queue destroyQueue;
+
+	static HeartFiberContext& Get();
+
+public:
+	// Attempt to yield the current fiber. This will return immediately
+	// if we are not currently executing within a fiber, and may effectively
+	// return immediately if there is no other queued work.
+	static void Yield();
+};

--- a/heart/heart-core/include/heart/fibers/fwd.h
+++ b/heart/heart-core/include/heart/fibers/fwd.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <heart/types.h>
+
+class HeartFiberWorkUnit;
+class HeartFiberContext;
+class HeartFiberSystem;
+enum class HeartFiberStatus : uint8_t;

--- a/heart/heart-core/include/heart/fibers/status.h
+++ b/heart/heart-core/include/heart/fibers/status.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <heart/fibers/fwd.h>
+
+enum class HeartFiberStatus : uint8_t
+{
+	Requeue,
+	Complete,
+};

--- a/heart/heart-core/include/heart/fibers/system.h
+++ b/heart/heart-core/include/heart/fibers/system.h
@@ -74,7 +74,14 @@ private:
 	void YieldUnit(HeartFiberWorkUnit& unit);
 
 	// Invoke the native method to pass execution to the given work unit.
-	[[noreturn]] void NativeSwitchToFiber(HeartFiberWorkUnit& target);
+	// Could return, if the current fiber is switched back to
+	void NativeSwitchToFiber(HeartFiberWorkUnit& target);
+
+	// Invoke the native method to pass execution to the given work unit.
+	// Can only be used in contexts where we know the current fiber will
+	// never be switched back to (eg the startup context, and when a work
+	// unit completes).
+	[[noreturn]] void NativeSwitchToFiberNoReturn(HeartFiberWorkUnit& target);
 
 public:
 	HeartFiberSystem(HeartBaseAllocator& allocator = GetHeartDefaultAllocator());

--- a/heart/heart-core/include/heart/fibers/system.h
+++ b/heart/heart-core/include/heart/fibers/system.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <heart/fibers/fwd.h>
+#include <heart/fibers/work_unit.h>
+
+#include <heart/allocator.h>
+#include <heart/memory/intrusive_list.h>
+#include <heart/memory/vector.h>
+#include <heart/sync/mutex.h>
+
+#include <heart/sleep.h>
+#include <heart/thread.h>
+
+#include <atomic>
+
+class HeartFiberSystem
+{
+public:
+	struct Settings
+	{
+		uint32_t threadCount = 1;
+	};
+
+private:
+	friend class HeartFiberContext;
+
+	// Allocator for the system. All allocations must be pulled from this and
+	// not from any global allocation source. Any failure to allocate will
+	// be instantly fatal and is not handled - the owner of this HeartFiberSystem
+	// MUST ensure the allocator is always successful.
+	HeartBaseAllocator& m_allocator;
+
+	// The list of threads used by this system for fibers
+	heart_priv::HeartVector<HeartThread> m_threads;
+
+	// List of fiber work awaiting execution. Mutex protected because
+	// the main thread can push work into it and the fiber thread(s)
+	// needs to both push and pull.
+	HeartFiberWorkUnit::Queue m_pendingQueue;
+	HeartMutex m_pendingQueueMutex;
+
+	// Flag to signal to the pumps that the system is shutting down.
+	std::atomic_bool m_exit = true;
+
+private:
+	// Static entry pointer for threads which will become fibers.
+	static void* HeartFiberThreadEntry(void* parameter);
+
+	// Global entry pointer for fiber work units. Invokes the work unit's
+	// worker, which can yield as many times as it likes. When it eventually
+	// exits, passes execution of the fiber back to the pump.
+	static void HeartFiberStartRoutine(void* parameter);
+
+	// The pump routine. Keeps all fiber threads alive throughout the
+	// system's lifetime and is responsible for pulling work units for each
+	// thread from the queue
+	HeartFiberStatus PumpRoutine();
+
+	// Prepare a work unit for actual execution by creating a native fiber for it.
+	// This can only be called from a thread which is already a fiber, so it is
+	// delegated to the pump for user work.
+	void InitializeWorkUnitNativeHandle(HeartFiberWorkUnit& unit);
+
+	// Finalize a work unit. Adds it to the destroy queue and passes execution
+	// to the pump.
+	void CompleteWorkUnit(HeartFiberWorkUnit& unit);
+
+	// Requeue a work unit. Internally, creates a copy with the same worker
+	// and adds the old work unit to the destroy queue before passing execution
+	// to the pump.
+	void RequeueWorkUnit(HeartFiberWorkUnit& unit);
+
+	// Yield the currently executing unit. Passes execution to the pump.
+	void YieldUnit(HeartFiberWorkUnit& unit);
+
+	// Invoke the native method to pass execution to the given work unit.
+	[[noreturn]] void NativeSwitchToFiber(HeartFiberWorkUnit& target);
+
+public:
+	HeartFiberSystem(HeartBaseAllocator& allocator = GetHeartDefaultAllocator());
+	~HeartFiberSystem();
+
+	void Initialize(Settings s);
+	void Shutdown();
+
+	// Add a work unit to the fiber system. Will be executed at some later point.
+	// F must be movable but is not required to be copyable.
+	template <typename F>
+	void EnqueueFiber(F&& f)
+	{
+		HeartFiberWorkUnit* newWorkUnit = m_allocator.AllocateAndConstruct<HeartFiberWorkUnit>(
+			HeartFiberWorkUnit::ConstructorSecret,
+			hrt::forward<F>(f));
+
+		{
+			HeartLockGuard lock(m_pendingQueueMutex);
+			m_pendingQueue.PushBack(newWorkUnit);
+		}
+	}
+};

--- a/heart/heart-core/include/heart/fibers/work_unit.h
+++ b/heart/heart-core/include/heart/fibers/work_unit.h
@@ -29,6 +29,11 @@ private:
 	WorkerFunction m_worker = {};
 
 public:
+	HeartFiberWorkUnit(ConstructorSecretType) :
+		HeartFiberWorkUnit()
+	{
+	}
+
 	template <typename F>
 	HeartFiberWorkUnit(ConstructorSecretType, F&& f) :
 		m_nativeHandle(nullptr),

--- a/heart/heart-core/include/heart/fibers/work_unit.h
+++ b/heart/heart-core/include/heart/fibers/work_unit.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <heart/fibers/fwd.h>
+
+#include <heart/function.h>
+#include <heart/memory/intrusive_list.h>
+
+#include <heart/stl/forward.h>
+
+class HeartFiberWorkUnit
+{
+public:
+	using WorkerFunction = HeartFunction<HeartFiberStatus()>;
+
+private:
+	struct ConstructorSecretType
+	{
+	};
+	static constexpr ConstructorSecretType ConstructorSecret = {};
+	friend class HeartFiberContext;
+	friend class HeartFiberSystem;
+
+	HeartFiberWorkUnit() = default;
+
+	void* m_nativeHandle = nullptr;
+
+	HeartIntrusiveListLink m_link = {};
+
+	WorkerFunction m_worker = {};
+
+public:
+	template <typename F>
+	HeartFiberWorkUnit(ConstructorSecretType, F&& f) :
+		m_nativeHandle(nullptr),
+		m_worker(hrt::forward<F>(f))
+	{
+	}
+
+	typedef HeartIntrusiveList<HeartFiberWorkUnit, &HeartFiberWorkUnit::m_link> Queue;
+};

--- a/heart/heart-core/src/fibers/context.cpp
+++ b/heart/heart-core/src/fibers/context.cpp
@@ -1,0 +1,21 @@
+#include "heart/fibers/context.h"
+
+#include "heart/fibers/system.h"
+
+HeartFiberContext& HeartFiberContext::Get()
+{
+	static thread_local HeartFiberContext context;
+	return context;
+}
+
+void HeartFiberContext::Yield()
+{
+	HeartFiberContext& ctx = Get();
+	if (!ctx.currentWorkUnit || !ctx.currentSystem)
+	{
+		// TODO: warn here? we tried to yield from a thread that's not a fiber
+		return;
+	}
+
+	ctx.currentSystem->YieldUnit(*ctx.currentWorkUnit);
+}

--- a/heart/heart-core/src/fibers/system.cpp
+++ b/heart/heart-core/src/fibers/system.cpp
@@ -1,0 +1,216 @@
+#include "heart/fibers/system.h"
+
+#include "heart/fibers/context.h"
+#include "heart/fibers/status.h"
+#include "heart/fibers/work_unit.h"
+
+#include "heart/debug/assert.h"
+
+#include "priv/SlimWin32.h"
+
+#include <stdio.h>
+
+struct HeartFiberThreadEntryParam
+{
+	enum State
+	{
+		Setup,
+		Ready,
+		Done,
+	};
+
+	std::atomic<State> state = State::Setup;
+
+	HeartFiberSystem* system = nullptr;
+};
+
+void* HeartFiberSystem::HeartFiberThreadEntry(void* parameter)
+{
+	// Wait for the main thread to fully populate the parameter
+	auto currentThread = (HeartFiberThreadEntryParam*)parameter;
+	while (currentThread->state < HeartFiberThreadEntryParam::Ready)
+	{
+		HeartYield();
+	}
+
+	// This thread is now a fiber
+	::ConvertThreadToFiberEx(NULL, FIBER_FLAG_FLOAT_SWITCH);
+
+	// Prepare the context for this thread
+	HeartFiberContext& threadContext = HeartFiberContext::Get();
+	threadContext.currentSystem = currentThread->system;
+	threadContext.pump.m_worker = []() { return HeartFiberContext::Get().currentSystem->PumpRoutine(); };
+
+	// Tell the main thread we're done reading the parameter
+	currentThread->state = HeartFiberThreadEntryParam::Done;
+	currentThread = nullptr;
+
+	// Initialize and execute the pump
+	threadContext.currentSystem->InitializeWorkUnitNativeHandle(threadContext.pump);
+	threadContext.currentSystem->NativeSwitchToFiber(threadContext.pump);
+}
+
+void HeartFiberSystem::HeartFiberStartRoutine(void* parameter)
+{
+	// Get the work unit and system from the context
+	HeartFiberWorkUnit& workUnit = *HeartFiberContext::Get().currentWorkUnit;
+	HeartFiberSystem* system = HeartFiberContext::Get().currentSystem;
+
+	// Begin execution of the work unit.
+	HeartFiberStatus result = workUnit.m_worker();
+
+	if (&workUnit == &HeartFiberContext::Get().pump)
+	{
+		// If the work unit was the pump, we're done. This will kill the thread.
+		return;
+	}
+	else if (result == HeartFiberStatus::Complete)
+	{
+		// Otherwise, if it completed, tell the system it's done.
+		// The system will handle switching to the pump.
+		system->CompleteWorkUnit(workUnit);
+	}
+	else
+	{
+		// Otherwise, if it needs to be requeued, inform the system.
+		// The system will handle switching to the pump.
+		system->RequeueWorkUnit(workUnit);
+	}
+}
+
+HeartFiberStatus HeartFiberSystem::PumpRoutine()
+{
+	auto canExit = [&]() {
+		bool destroyEmpty = HeartFiberContext::Get().destroyQueue.IsEmpty();
+
+		bool pendingEmpty;
+		{
+			HeartLockGuard lock(m_pendingQueueMutex);
+			pendingEmpty = m_pendingQueue.IsEmpty();
+		}
+
+		return destroyEmpty && pendingEmpty && m_exit;
+	};
+
+	while (!canExit())
+	{
+		// Destroy any fibers that completed on this thread.
+		while (!HeartFiberContext::Get().destroyQueue.IsEmpty())
+		{
+			HeartFiberWorkUnit* unit = HeartFiberContext::Get().destroyQueue.PopFront();
+			::DeleteFiber(unit->m_nativeHandle);
+			m_allocator.DestroyAndFree(unit);
+		}
+
+		// Grab our next work unit
+		HeartFiberWorkUnit* next = nullptr;
+		{
+			HeartLockGuard lock(m_pendingQueueMutex);
+			next = m_pendingQueue.PopFront();
+		}
+
+		if (next != nullptr)
+		{
+			if (next->m_nativeHandle == nullptr)
+			{
+				InitializeWorkUnitNativeHandle(*next);
+			}
+
+			NativeSwitchToFiber(*next);
+		}
+		else
+		{
+			HeartSleep(5);
+		}
+	}
+
+	return HeartFiberStatus::Complete;
+}
+
+void HeartFiberSystem::InitializeWorkUnitNativeHandle(HeartFiberWorkUnit& unit)
+{
+	// We can only create fibers from a fiber!
+	HEART_ASSERT(HeartFiberContext::Get().currentSystem != nullptr);
+
+	unit.m_nativeHandle = ::CreateFiberEx(0, 0, FIBER_FLAG_FLOAT_SWITCH, &HeartFiberStartRoutine, NULL);
+}
+
+void HeartFiberSystem::CompleteWorkUnit(HeartFiberWorkUnit& unit)
+{
+	HeartFiberContext::Get().destroyQueue.PushBack(&unit);
+
+	NativeSwitchToFiber(HeartFiberContext::Get().pump);
+}
+
+void HeartFiberSystem::RequeueWorkUnit(HeartFiberWorkUnit& unit)
+{
+	EnqueueFiber(hrt::move(unit.m_worker));
+
+	CompleteWorkUnit(unit);
+}
+
+void HeartFiberSystem::YieldUnit(HeartFiberWorkUnit& unit)
+{
+	{
+		HeartLockGuard lock(m_pendingQueueMutex);
+		m_pendingQueue.PushBack(&unit);
+	}
+
+	NativeSwitchToFiber(HeartFiberContext::Get().pump);
+}
+
+void HeartFiberSystem::NativeSwitchToFiber(HeartFiberWorkUnit& target)
+{
+	// Populate the context
+	HEART_ASSERT(HeartFiberContext::Get().currentSystem == this);
+	HeartFiberContext::Get().currentWorkUnit = &target;
+
+	// Execute
+	::SwitchToFiber(target.m_nativeHandle);
+}
+
+HeartFiberSystem::HeartFiberSystem(HeartBaseAllocator& allocator) :
+	m_allocator(allocator),
+	m_threads(allocator)
+{
+}
+
+HeartFiberSystem::~HeartFiberSystem()
+{
+	HEART_ASSERT(m_exit);
+	HEART_ASSERT(m_threads.IsEmpty());
+}
+
+void HeartFiberSystem::Initialize(Settings s)
+{
+	m_exit = false;
+
+	m_threads.Reserve(s.threadCount);
+	for (uint32_t i = 0; i < s.threadCount; ++i)
+	{
+		HeartFiberThreadEntryParam param;
+		param.system = this;
+
+		HeartThread& thread = m_threads.EmplaceBack(HeartThread(&HeartFiberThreadEntry, &param));
+		param.state = HeartFiberThreadEntryParam::Ready;
+
+		char buffer[64];
+		sprintf_s(buffer, "HeartFiber Thread %u", i + 1);
+		thread.SetName(buffer);
+
+		while (param.state < HeartFiberThreadEntryParam::Done)
+		{
+			HeartYield();
+		}
+	}
+}
+
+void HeartFiberSystem::Shutdown()
+{
+	m_exit = true;
+
+	for (auto& thread : m_threads)
+		thread.Join();
+
+	m_threads.Clear();
+}

--- a/heart/heart-test/src/fibers.cpp
+++ b/heart/heart-test/src/fibers.cpp
@@ -1,0 +1,173 @@
+#include <heart/fibers/context.h>
+#include <heart/fibers/status.h>
+#include <heart/fibers/system.h>
+
+#include <gtest/gtest.h>
+
+#include <mutex>
+#include <thread>
+#include <vector>
+
+TEST(Fibers, BasicStartupShutdown)
+{
+	HeartFiberSystem system;
+
+	system.Initialize({});
+	system.Shutdown();
+}
+
+TEST(Fibers, SingleWorkUnit)
+{
+	HeartFiberSystem system;
+
+	system.Initialize({});
+
+	static int32_t someData = 0;
+
+	system.EnqueueFiber([]() {
+		EXPECT_EQ(someData, 0);
+		someData = 1;
+		return HeartFiberStatus::Complete;
+	});
+
+	system.Shutdown();
+
+	EXPECT_EQ(someData, 1);
+}
+
+TEST(Fibers, MultiWorkUnit)
+{
+	HeartFiberSystem system;
+	system.Initialize({});
+
+	static int32_t someData = 0;
+
+	auto worker = []() {
+		++someData;
+		return HeartFiberStatus::Complete;
+	};
+
+	system.EnqueueFiber(worker);
+	system.EnqueueFiber(worker);
+	system.EnqueueFiber(worker);
+	system.EnqueueFiber(worker);
+	system.EnqueueFiber(worker);
+
+	system.Shutdown();
+
+	EXPECT_EQ(someData, 5);
+}
+
+TEST(Fibers, YieldingWorkUnit)
+{
+	HeartFiberSystem system;
+	system.Initialize({});
+
+	static std::atomic_bool job2Queued = false;
+
+	enum State
+	{
+		None,
+		Job1Waiting,
+		Job1Yielding,
+		Job2Yielding,
+		Job1Finished,
+		Job2Finished,
+	};
+
+	static State state = None;
+
+	system.EnqueueFiber([]() {
+		EXPECT_EQ(state, None);
+		state = Job1Waiting;
+
+		while (!job2Queued)
+			std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+		state = Job1Yielding;
+		HeartFiberContext::Yield();
+
+		EXPECT_EQ(state, Job2Yielding);
+
+		state = Job1Finished;
+		return HeartFiberStatus::Complete;
+	});
+
+	system.EnqueueFiber([]() {
+		EXPECT_EQ(state, Job1Yielding);
+
+		state = Job2Yielding;
+		HeartFiberContext::Yield();
+
+		state = Job2Finished;
+		return HeartFiberStatus::Complete;
+	});
+	job2Queued = true;
+
+	system.Shutdown();
+	EXPECT_EQ(state, Job2Finished);
+}
+
+TEST(Fibers, Requeue)
+{
+	HeartFiberSystem system;
+	system.Initialize({});
+
+	std::atomic<int32_t> counter = 0;
+	system.EnqueueFiber([&]() {
+		if (++counter < 5)
+		{
+			return HeartFiberStatus::Requeue;
+		}
+
+		return HeartFiberStatus::Complete;
+	});
+
+	system.Shutdown();
+	EXPECT_EQ(counter, 5);
+}
+
+TEST(Fibers, FourThreads)
+{
+	HeartFiberSystem::Settings settings;
+	settings.threadCount = 4;
+
+	HeartFiberSystem system;
+	system.Initialize(settings);
+
+	const int JobCount = 128;
+	std::atomic_int doneCount = 0;
+
+	std::mutex threadIdsMutex;
+	std::vector<std::thread::id> threadIds;
+
+	int i = JobCount;
+	while (i--)
+	{
+		system.EnqueueFiber([&]() {
+			{
+				std::lock_guard lock(threadIdsMutex);
+				if (std::find(threadIds.begin(), threadIds.end(), std::this_thread::get_id()) == threadIds.end())
+				{
+					threadIds.push_back(std::this_thread::get_id());
+				}
+			}
+
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			doneCount++;
+
+			return HeartFiberStatus::Complete;
+		});
+	}
+
+	while (doneCount < JobCount)
+		std::this_thread::yield();
+
+	// With so many long-running jobs, we expect every thread to have been hit
+	EXPECT_EQ(threadIds.size(), settings.threadCount);
+
+	// And they should've all finished
+	EXPECT_EQ(doneCount, JobCount);
+
+	system.Shutdown();
+}


### PR DESCRIPTION
The main difference is the lack of trackability of pushed work and the fact that everyone on the internet says you cannot use normal sync objects with fibers, although I'm having trouble imagining a scenario where fibers would deadlock but regular jobs would not.