### PR TITLE
Add constexpr murmurhash

### DIFF
--- a/game/premake5.lua
+++ b/game/premake5.lua
@@ -9,7 +9,6 @@ project "sfml-demo"
 	include_tweeny()
 	include_cxxopts()
 	include_icon_headers()
-	include_murmerhash(true)
 	debugdir "%{wks.location}/"
 
 	defines {

--- a/game/src/main.cpp
+++ b/game/src/main.cpp
@@ -1,7 +1,3 @@
-#include <heart/fibers/status.h>
-#include <heart/fibers/system.h>
-#include <heart/sync/event.h>
-
 #include "cmd_line.h"
 
 #include "game/game.h"
@@ -15,6 +11,10 @@
 #include "tween/tween_manager.h"
 
 #include <heart/file.h>
+
+#include <heart/fibers/status.h>
+#include <heart/fibers/system.h>
+#include <heart/sync/event.h>
 
 static bool s_shutdown = false;
 

--- a/game/src/tiles/tile_manager.cpp
+++ b/game/src/tiles/tile_manager.cpp
@@ -6,6 +6,7 @@
 #include "render/imgui_game.h"
 #include "render/render.h"
 
+#include <heart/hash/murmur.h>
 #include <heart/scope_exit.h>
 
 #include <heart/deserialization/deserialization_file.h>
@@ -13,7 +14,6 @@
 
 #include <SFML/Graphics.hpp>
 #include <icons/IconsKenney.h>
-#include <smhasher/src/MurmurHash3.h>
 
 #include <algorithm>
 
@@ -86,7 +86,7 @@ void TileManager::Initialize(const char* listPath)
 			hrt::string hashedName = tilesets.filelist[i].c_str();
 			hashedName.append(entry.name.c_str());
 
-			MurmurHash3_x86_32(hashedName.c_str(), int(hashedName.size()), TileSeed, &entry.key);
+			entry.key = HeartMurmurHash3(hashedName, TileSeed);
 
 			HEART_ASSERT(m_spritemap.find(entry.key) == m_spritemap.end(), "HASH COLLISION IN TILE MANAGER!");
 			m_spritemap[entry.key] = hrt::make_pair(i, j);

--- a/heart/heart-core/include/heart/hash/murmur.h
+++ b/heart/heart-core/include/heart/hash/murmur.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <heart/types.h>
+
+#include <heart/stl/type_traits/enable_if.h>
+
+#include <bit>
+#include <string_view>
+
+namespace heart_priv
+{
+	template <typename T, typename Enable = void>
+	struct HeartMurmurHashHelper;
+
+	template <typename T>
+	struct HeartMurmurHashHelper<T, hrt::enable_if_t<sizeof(T) == 1>>
+	{
+		const T* const buffer;
+		const size_t size;
+
+		constexpr HeartMurmurHashHelper(const T* const b, const size_t s) :
+			buffer(b), size(s)
+		{
+		}
+
+		constexpr uint32_t GetBlock32(int index) const
+		{
+			int i = index * 4;
+			return uint32_t(std::bit_cast<uint8_t>(buffer[i + 0])) |
+				   uint32_t(std::bit_cast<uint8_t>(buffer[i + 1])) << 8u |
+				   uint32_t(std::bit_cast<uint8_t>(buffer[i + 2])) << 16u |
+				   uint32_t(std::bit_cast<uint8_t>(buffer[i + 3])) << 24u;
+		}
+
+		constexpr uint32_t GetTail(int tail) const
+		{
+			const int tailSize = size % 4;
+			return uint32_t(std::bit_cast<uint8_t>(buffer[size - tailSize + tail]));
+		}
+	};
+
+	template <typename T>
+	struct HeartMurmurHashHelper<T, hrt::enable_if_t<sizeof(T) == 2>>
+	{
+		const T* const buffer;
+		const size_t size;
+
+		constexpr HeartMurmurHashHelper(const T* const b, const size_t s) :
+			buffer(b), size(s)
+		{
+		}
+
+		constexpr uint32_t GetBlock32(int index) const
+		{
+			int i = index * 2;
+			return uint32_t(std::bit_cast<uint16_t>(buffer[i + 0])) |
+				   uint32_t(std::bit_cast<uint16_t>(buffer[i + 1])) << 16u;
+		}
+
+		constexpr uint32_t GetTail(int tail) const
+		{
+			T tailValue = buffer[size - 1];
+			if (tail == 0)
+				return uint8_t(tailValue);
+			else
+				return uint8_t(tailValue >> 8u);
+		}
+	};
+
+	template <typename T>
+	struct HeartMurmurHashHelper<T, hrt::enable_if_t<sizeof(T) == 4>>
+	{
+		const T* const buffer;
+		const size_t size;
+
+		constexpr HeartMurmurHashHelper(const T* const b, const size_t s) :
+			buffer(b), size(s)
+		{
+		}
+
+		constexpr uint32_t GetBlock32(int index) const
+		{
+			return buffer[index];
+		}
+	};
+
+	template <typename T>
+	struct HeartMurmurHashHelper<T, hrt::enable_if_t<sizeof(T) == 8>>
+	{
+		const T* const buffer;
+		const size_t size;
+
+		constexpr HeartMurmurHashHelper(const T* const b, const size_t s) :
+			buffer(b), size(s)
+		{
+		}
+
+		constexpr uint32_t GetBlock32(int index) const
+		{
+			const int i = index / 2;
+			const int shift = index % 2 == 0 ? 0u : 32u;
+			return uint32_t(buffer[i] >> shift);
+		}
+	};
+
+	// Support everything else too. This requires reinterpret_cast and cannot be constexpr though.
+	template <typename T>
+	struct HeartMurmurHashHelper<T, hrt::enable_if_t<sizeof(T) != 1 && sizeof(T) != 2 && sizeof(T) != 4 && sizeof(T) != 8>>
+	{
+		const uint8_t* const buffer;
+		const size_t size;
+
+		HeartMurmurHashHelper(const T* const b, const size_t s) :
+			buffer(reinterpret_cast<const uint8_t* const>(b)), size(s * sizeof(T))
+		{
+		}
+
+		uint32_t GetBlock32(int index) const
+		{
+			int i = index * 4;
+			return uint32_t(buffer[i + 0]) |
+				   uint32_t(buffer[i + 1]) << 8u |
+				   uint32_t(buffer[i + 2]) << 16u |
+				   uint32_t(buffer[i + 3]) << 24u;
+		}
+
+		uint32_t GetTail(int tail) const
+		{
+			const int tailSize = size % 4;
+			return uint32_t(std::bit_cast<uint8_t>(buffer[size - tailSize + tail]));
+		}
+	};
+}
+
+constexpr static uint32_t HeartMurmurHash3DefaultSeed = 0x7C44A16D;
+
+template <typename T>
+constexpr uint32_t HeartMurmurHash3(const T* const data, const size_t count, const uint32_t seed = HeartMurmurHash3DefaultSeed)
+{
+	heart_priv::HeartMurmurHashHelper<T> helper(data, count);
+
+	uint32_t h1 = seed;
+	const int len = int(count * sizeof(T));
+	const int nblocks = len / 4;
+
+	const uint32_t c1 = 0xcc9e2d51;
+	const uint32_t c2 = 0x1b873593;
+
+	// Body
+	for (int i = 0; i < nblocks; ++i)
+	{
+		uint32_t k1 = helper.GetBlock32(i);
+
+		k1 *= c1;
+		k1 = std::rotl(k1, 15);
+		k1 *= c2;
+
+		h1 ^= k1;
+		h1 = std::rotl(h1, 13);
+		h1 = h1 * 5 + 0xe6546b64;
+	}
+
+	// Tail
+	if constexpr (sizeof(T) < 4)
+	{
+		uint32_t k1 = 0;
+		switch (len & 3)
+		{
+		case 3:
+			k1 ^= helper.GetTail(2) << 16;
+			[[fallthrough]];
+		case 2:
+			k1 ^= helper.GetTail(1) << 8;
+			[[fallthrough]];
+		case 1:
+			k1 ^= helper.GetTail(0);
+			k1 *= c1;
+			k1 = std::rotl(k1, 15);
+			k1 *= c2;
+			h1 ^= k1;
+		}
+	}
+
+	h1 ^= len;
+	h1 ^= h1 >> 16;
+	h1 *= 0x85ebca6b;
+	h1 ^= h1 >> 13;
+	h1 *= 0xc2b2ae35;
+	h1 ^= h1 >> 16;
+
+	return h1;
+}
+
+constexpr uint32_t HeartMurmurHash3(std::string_view string, uint32_t seed = HeartMurmurHash3DefaultSeed)
+{
+	return HeartMurmurHash3(string.data(), string.size(), seed);
+}

--- a/heart/heart-test/premake5.lua
+++ b/heart/heart-test/premake5.lua
@@ -5,6 +5,7 @@ project "heart-test"
 	include_self()
 	include_heart(true)
 	include_entt()
+	include_murmerhash(true)
 	include_googletest(true)
 
 	includedirs {

--- a/heart/heart-test/src/hash.cpp
+++ b/heart/heart-test/src/hash.cpp
@@ -1,0 +1,146 @@
+#include <heart/hash/murmur.h>
+
+#include <gtest/gtest.h>
+
+#include <smhasher/src/MurmurHash3.h>
+
+constexpr uint32_t CompileTimeTest = HeartMurmurHash3("Heart Murmurhash Compile Time Test");
+
+TEST(MurmurHash, CompileTimeString)
+{
+	std::string_view str("Heart Murmurhash Compile Time Test");
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(str.data(), int(str.size()), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(theirResult, CompileTimeTest);
+}
+
+TEST(MurmurHash, int8)
+{
+	int8_t dataBlock[] = {116, 50, 95, -66, 83, 82, 16, 113, -84, -98, -68, -126, -87};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, uint8)
+{
+	uint8_t dataBlock[] = {206, 247, 131, 148, 48, 202, 56, 45, 14, 148, 66, 179, 246};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, char)
+{
+	char dataBlock[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd'};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, int16)
+{
+	int16_t dataBlock[] = {1630, 14322, -3077, 13559, 7146, 9661, 7298, 7792, -14984, 7571, -8883, 5025, 9336};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock) / sizeof(int16_t));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, uint16)
+{
+	uint16_t dataBlock[] = {20399, 19899, 31692, 13863, 16941, 11613, 14892, 746, 10620, 7331, 31468, 26272, 14066};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock) / sizeof(uint16_t));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, int32)
+{
+	int32_t dataBlock[] = {1654508, 876206, -1949660, 2009014, -1798597, -523854, -2529957, 924645, -1010157, 863839, 1860515, 2457578, 650635};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock) / sizeof(int32_t));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, uint32)
+{
+	uint32_t dataBlock[] = {136737210, 139783947, 427530759, 131542, 381706335, 140753215, 428140249, 187343278, 90080884, 3900185, 366672134, 84169969, 193066025};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock) / sizeof(uint32_t));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, uint64)
+{
+	uint64_t dataBlock[] = {0xFAFFBAFFBEEF4B1D, 0xCAFEBABEDEADBEEF, 0xFACEFACEFACEFACE, 0xDEADC0DE0FF1CE};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock) / sizeof(uint64_t));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, int64)
+{
+	int64_t dataBlock[] = {std::bit_cast<int64_t>(0xFAFFBAFFBEEF4B1D), std::bit_cast<int64_t>(0xCAFEBABEDEADBEEF), std::bit_cast<int64_t>(0xFACEFACEFACEFACE), std::bit_cast<int64_t>(0xDEADC0DE0FF1CE21)};
+
+	uint32_t ourResult = HeartMurmurHash3(dataBlock, sizeof(dataBlock) / sizeof(int64_t));
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(dataBlock, int(sizeof(dataBlock)), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}
+
+TEST(MurmurHash, structure)
+{
+	struct MyWeirdStruct
+	{
+		uint64_t value1 = 0xFACEFACEFACEFACE;
+		char value2 = 's';
+		uint32_t value3 = 4275307592;
+	};
+
+	static_assert(sizeof(MyWeirdStruct) > 8);
+
+	MyWeirdStruct value;
+
+	uint32_t ourResult = HeartMurmurHash3(&value, 1);
+
+	uint32_t theirResult = 0;
+	MurmurHash3_x86_32(&value, sizeof(value), HeartMurmurHash3DefaultSeed, &theirResult);
+
+	EXPECT_EQ(ourResult, theirResult);
+}


### PR DESCRIPTION
Remove murmurhash dependency from the game

Add our own implementation which can be evaluated at compile time if the type is (u)int8, (u)int16, (u)int32, or (u)int64. Structures are also supported, but cannot be evaluated at compile time.