### PR TITLE
Fix failing job system unit test by clearing worker before setting status

### DIFF
--- a/heart/heart-core/src/jobs/system.cpp
+++ b/heart/heart-core/src/jobs/system.cpp
@@ -210,13 +210,13 @@ void HeartJobSystem::ProcessOneJob(HeartJobRef job, HeartJobPriority priority)
 	auto result = job->worker();
 	if (result == HeartJobResult::Success)
 	{
-		job->status = HeartJobStatus::Success;
 		job->worker.Clear();
+		job->status = HeartJobStatus::Success;
 	}
 	else if (result == HeartJobResult::Failure)
 	{
-		job->status = HeartJobStatus::Failure;
 		job->worker.Clear();
+		job->status = HeartJobStatus::Failure;
 	}
 	else if (result == HeartJobResult::Retry)
 	{


### PR DESCRIPTION
Fixes a race condition in the "MoveOnlyJob" test where the main thread would expect the job system thread to have cleaned up the functor as soon as the job status was set to `Success` but this was not previously a guarantee.