### PR TITLE
Add HeartDynamicFunction

### DIFF
--- a/heart/heart-core/include/heart/fibers/work_unit.h
+++ b/heart/heart-core/include/heart/fibers/work_unit.h
@@ -2,7 +2,7 @@
 
 #include <heart/fibers/fwd.h>
 
-#include <heart/function.h>
+#include <heart/function/embedded_function.h>
 #include <heart/memory/intrusive_list.h>
 
 #include <heart/stl/forward.h>
@@ -10,7 +10,7 @@
 class HeartFiberWorkUnit
 {
 public:
-	using WorkerFunction = HeartFunction<HeartFiberStatus(), 96>;
+	using WorkerFunction = HeartEmbeddedFunction<HeartFiberStatus(), 96>;
 
 private:
 	struct ConstructorSecretType

--- a/heart/heart-core/include/heart/function/details_function_base.h
+++ b/heart/heart-core/include/heart/function/details_function_base.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <heart/stl/forward.h>
+#include <heart/stl/move.h>
+#include <heart/stl/type_traits/add_remove_ref_cv.h>
+#include <heart/stl/type_traits/same.h>
+
+namespace heart_priv
+{
+	template <typename R, typename... Args>
+	class HeartFunctionBase
+	{
+	public:
+		virtual R Call(Args&&... args) = 0;
+		virtual void Move(void* location) = 0;
+		virtual ~HeartFunctionBase() = default;
+	};
+
+	template <typename F, typename R, typename... Args>
+	class HeartFunctionImpl : public HeartFunctionBase<R, Args...>
+	{
+		static_assert(hrt::is_same_v<F, hrt::remove_reference_t<F>>);
+		F f;
+
+	public:
+		HeartFunctionImpl(F&& f) :
+			f(hrt::forward<F>(f))
+		{
+		}
+
+		~HeartFunctionImpl() = default;
+
+		R Call(Args&&... args) override
+		{
+			return f(hrt::forward<Args>(args)...);
+		}
+
+		void Move(void* location) override
+		{
+			new (location) HeartFunctionImpl<F, R, Args...>(hrt::move(f));
+		}
+	};
+}

--- a/heart/heart-core/include/heart/function/details_function_base.h
+++ b/heart/heart-core/include/heart/function/details_function_base.h
@@ -12,8 +12,9 @@ namespace heart_priv
 	{
 	public:
 		virtual R Call(Args&&... args) = 0;
-		virtual void Move(void* location) = 0;
+		virtual HeartFunctionBase* Move(void* location) = 0;
 		virtual ~HeartFunctionBase() = default;
+		virtual size_t GetSize() const = 0;
 	};
 
 	template <typename F, typename R, typename... Args>
@@ -35,9 +36,15 @@ namespace heart_priv
 			return f(hrt::forward<Args>(args)...);
 		}
 
-		void Move(void* location) override
+		HeartFunctionBase<R, Args...>* Move(void* location) override
 		{
-			new (location) HeartFunctionImpl<F, R, Args...>(hrt::move(f));
+			auto* p = new (location) HeartFunctionImpl<F, R, Args...>(hrt::move(f));
+			return p;
+		}
+
+		size_t GetSize() const override
+		{
+			return sizeof(HeartFunctionImpl<F, R, Args...>);
 		}
 	};
 }

--- a/heart/heart-core/include/heart/function/dynamic_function.h
+++ b/heart/heart-core/include/heart/function/dynamic_function.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <heart/function/details_function_base.h>
+
+#include <heart/allocator.h>
+
+#include <heart/debug/assert.h>
+
+template <typename Sig>
+class HeartDynamicFunction;
+
+template <typename R, typename... Args>
+class HeartDynamicFunction<R(Args...)>
+{
+private:
+	using BaseType = heart_priv::HeartFunctionBase<R, Args...>;
+
+	template <typename F>
+	using ImplType = heart_priv::HeartFunctionImpl<hrt::remove_reference_t<F>, R, Args...>;
+
+	BaseType* m_pointer = nullptr;
+	HeartBaseAllocator& m_allocator;
+
+public:
+	HeartDynamicFunction(HeartBaseAllocator& a = GetHeartDefaultAllocator()) :
+		m_allocator(a)
+	{
+	}
+
+	DISABLE_COPY_SEMANTICS(HeartDynamicFunction);
+
+	HeartDynamicFunction(HeartDynamicFunction&& o) :
+		HeartDynamicFunction(o.m_allocator)
+	{
+		Swap(o);
+	}
+
+	HeartDynamicFunction& operator=(HeartDynamicFunction&& o)
+	{
+		Swap(o);
+		return *this;
+	}
+
+	template <typename F>
+	HeartDynamicFunction(F f, HeartBaseAllocator& a = GetHeartDefaultAllocator()) :
+		HeartDynamicFunction(a)
+	{
+		Set(hrt::forward<F>(f));
+	}
+
+	template <typename F>
+	void Set(F& f)
+	{
+		m_pointer = m_allocator.AllocateAndConstruct<ImplType<F>>(hrt::forward<F>(f));
+	}
+
+	template <typename F>
+	void Set(F&& f)
+	{
+		m_pointer = m_allocator.AllocateAndConstruct<ImplType<F>>(hrt::forward<F>(f));
+	}
+
+	void Clear()
+	{
+		if (m_pointer != nullptr)
+		{
+			m_allocator.DestroyAndFree(m_pointer);
+			m_pointer = nullptr;
+		}
+	}
+
+	bool IsSet() const
+	{
+		return m_pointer != nullptr;
+	}
+
+	void Swap(HeartDynamicFunction& o)
+	{
+		if (&this->m_allocator == &o.m_allocator)
+		{
+			// Same allocator, just a pointer swap
+			BaseType* tmp = m_pointer;
+			m_pointer = o.m_pointer;
+			o.m_pointer = tmp;
+		}
+		else
+		{
+			BaseType* tPtr = m_pointer;
+			BaseType* oPtr = o.m_pointer;
+			m_pointer = nullptr;
+			o.m_pointer = nullptr;
+
+			auto movePointer = [](BaseType*& target, BaseType*& source, HeartBaseAllocator& targetAllocator, HeartBaseAllocator& sourceAllocator) {
+				void* newStorage = targetAllocator.RawAllocate(source->GetSize());
+				target = source->Move(newStorage);
+				sourceAllocator.DestroyAndFree(source);
+				source = nullptr;
+			};
+
+			if (tPtr)
+			{
+				movePointer(o.m_pointer, tPtr, o.m_allocator, m_allocator);
+			}
+
+			if (oPtr)
+			{
+				movePointer(m_pointer, oPtr, m_allocator, o.m_allocator);
+			}
+		}
+	}
+
+	explicit operator bool() const
+	{
+		return IsSet();
+	}
+
+	R operator()(Args... args)
+	{
+		HEART_ASSERT(IsSet());
+		return m_pointer->Call(hrt::forward<Args>(args)...);
+	}
+};

--- a/heart/heart-core/include/heart/jobs/system.h
+++ b/heart/heart-core/include/heart/jobs/system.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <heart/allocator.h>
-#include <heart/function.h>
+#include <heart/function/embedded_function.h>
 #include <heart/memory/intrusive_list.h>
 #include <heart/memory/intrusive_ptr.h>
 #include <heart/memory/vector.h>
@@ -79,7 +79,7 @@ private:
 	HeartBaseAllocator& allocator;
 
 	// Our actual job execution function
-	HeartFunction<HeartJobResult(), HeartJobStorage> worker = {};
+	HeartEmbeddedFunction<HeartJobResult(), HeartJobStorage> worker = {};
 
 public:
 	template <typename F>

--- a/heart/heart-test/src/dynamic_function.cpp
+++ b/heart/heart-test/src/dynamic_function.cpp
@@ -1,0 +1,368 @@
+#include <heart/function/dynamic_function.h>
+
+#include <gtest/gtest.h>
+
+#include "utils/tracking_allocator.h"
+
+#include <array>
+
+constexpr int SecretValue = 0xF00DFEED;
+
+int DynamicFunctionTestVisibleFunction()
+{
+	return SecretValue;
+}
+
+static int DynamicFunctionTestStaticFunction()
+{
+	return SecretValue;
+}
+
+TEST(HeartDynamicFunction, GlobalFunctionPointer)
+{
+	HeartDynamicFunction<int()> adapter1(&DynamicFunctionTestVisibleFunction);
+	EXPECT_TRUE(adapter1);
+	EXPECT_FALSE(!adapter1);
+	EXPECT_TRUE(!!adapter1);
+
+	int result = adapter1();
+	EXPECT_EQ(result, SecretValue);
+}
+
+TEST(HeartDynamicFunction, DynamicFunctionTestStaticFunctionPointer)
+{
+	HeartDynamicFunction<int()> adapter1(&DynamicFunctionTestStaticFunction);
+	EXPECT_TRUE(adapter1);
+	EXPECT_FALSE(!adapter1);
+	EXPECT_TRUE(!!adapter1);
+
+	int result = adapter1();
+	EXPECT_EQ(result, SecretValue);
+}
+
+TEST(HeartDynamicFunction, SwappableToEmpty)
+{
+	HeartDynamicFunction<int()> adapter1(&DynamicFunctionTestVisibleFunction);
+	EXPECT_TRUE(adapter1);
+	EXPECT_FALSE(!adapter1);
+	EXPECT_TRUE(!!adapter1);
+
+	int result1 = adapter1();
+	EXPECT_EQ(result1, SecretValue);
+
+	HeartDynamicFunction<int()> adapter2;
+	EXPECT_FALSE(adapter2);
+	EXPECT_TRUE(!adapter2);
+	EXPECT_FALSE(!!adapter2);
+
+	adapter1.Swap(adapter2);
+
+	EXPECT_TRUE(adapter2);
+	EXPECT_FALSE(adapter1);
+
+	EXPECT_DEATH(adapter1(), ".*");
+
+	int result2 = adapter2();
+	EXPECT_EQ(result2, SecretValue);
+	EXPECT_EQ(result1, result2);
+}
+
+TEST(HeartDynamicFunction, SwappableToFull)
+{
+	HeartDynamicFunction<int()> adapter1(&DynamicFunctionTestVisibleFunction);
+	EXPECT_TRUE(adapter1);
+	EXPECT_FALSE(!adapter1);
+	EXPECT_TRUE(!!adapter1);
+
+	int result1 = adapter1();
+	EXPECT_EQ(result1, SecretValue);
+
+	HeartDynamicFunction<int()> adapter2(&DynamicFunctionTestVisibleFunction);
+	EXPECT_TRUE(adapter2);
+	EXPECT_FALSE(!adapter2);
+	EXPECT_TRUE(!!adapter2);
+
+	adapter1.Swap(adapter2);
+
+	EXPECT_TRUE(adapter2);
+	EXPECT_TRUE(adapter1);
+
+	int result2 = adapter2();
+	int result3 = adapter1();
+	EXPECT_EQ(result2, SecretValue);
+	EXPECT_EQ(result3, SecretValue);
+	EXPECT_EQ(result1, result2);
+	EXPECT_EQ(result1, result3);
+}
+
+TEST(HeartDynamicFunction, ComplexSwap)
+{
+	static int moveCount = 0;
+
+	struct UncopyableFunctor
+	{
+		DISABLE_COPY_SEMANTICS(UncopyableFunctor);
+
+		int value;
+
+		UncopyableFunctor() :
+			value(0)
+		{
+		}
+
+		UncopyableFunctor(UncopyableFunctor&& o) :
+			value(SecretValue)
+		{
+			moveCount++;
+		}
+
+		int operator()() const
+		{
+			return SecretValue;
+		}
+	};
+
+	HeartDynamicFunction<int()> adapter1(UncopyableFunctor {});
+	EXPECT_EQ(moveCount, 1);
+	EXPECT_TRUE(adapter1);
+	EXPECT_FALSE(!adapter1);
+	EXPECT_TRUE(!!adapter1);
+
+	int result1 = adapter1();
+	EXPECT_EQ(result1, SecretValue);
+
+	HeartDynamicFunction<int()> adapter2(UncopyableFunctor {});
+	EXPECT_EQ(moveCount, 2);
+	EXPECT_TRUE(adapter1);
+	EXPECT_FALSE(!adapter1);
+	EXPECT_TRUE(!!adapter1);
+
+	adapter1.Swap(adapter2);
+	EXPECT_GE(moveCount, 2);
+
+	EXPECT_TRUE(adapter1);
+	EXPECT_TRUE(adapter2);
+
+	int result2 = adapter2();
+	int result3 = adapter1();
+	EXPECT_EQ(result2, SecretValue);
+	EXPECT_EQ(result3, SecretValue);
+}
+
+TEST(HeartDynamicFunction, Moveable)
+{
+	HeartDynamicFunction<int()> adapter1(&DynamicFunctionTestStaticFunction);
+	EXPECT_TRUE(adapter1);
+
+	HeartDynamicFunction<int()> adapter2;
+	EXPECT_FALSE(adapter2);
+
+	adapter2 = hrt::move(adapter1);
+
+	EXPECT_FALSE(adapter1);
+	EXPECT_DEATH(adapter1(), ".*");
+	EXPECT_TRUE(adapter2);
+
+	int result = adapter2();
+	EXPECT_EQ(result, SecretValue);
+}
+
+TEST(HeartDynamicFunction, CapturelessLambda)
+{
+	HeartDynamicFunction<int()> adapter([]() {
+		return SecretValue;
+	});
+	EXPECT_TRUE(adapter);
+	EXPECT_FALSE(!adapter);
+	EXPECT_TRUE(!!adapter);
+
+	int result = adapter();
+	EXPECT_EQ(result, SecretValue);
+}
+
+TEST(HeartDynamicFunction, StatefulLambda)
+{
+	int theSecret = SecretValue;
+
+	HeartDynamicFunction<int()> adapter([theSecret]() {
+		return theSecret;
+	});
+
+	EXPECT_TRUE(adapter);
+	EXPECT_FALSE(!adapter);
+	EXPECT_TRUE(!!adapter);
+
+	int result = adapter();
+	EXPECT_EQ(result, SecretValue);
+}
+
+TEST(HeartDynamicFunction, NoCopyParameter)
+{
+	struct NoCopyType
+	{
+		int v;
+
+		NoCopyType() :
+			v(SecretValue)
+		{
+		}
+
+		NoCopyType(const NoCopyType&) = delete;
+		NoCopyType& operator=(const NoCopyType&) = delete;
+	};
+
+	NoCopyType parameter;
+
+	HeartDynamicFunction<int(const NoCopyType&)> constRefAdapter([](const NoCopyType& p) {
+		return p.v;
+	});
+
+	EXPECT_TRUE(constRefAdapter);
+	EXPECT_FALSE(!constRefAdapter);
+	EXPECT_TRUE(!!constRefAdapter);
+
+	int result = constRefAdapter(parameter);
+	EXPECT_EQ(result, SecretValue);
+
+	HeartDynamicFunction<int(NoCopyType&)> mutableRefAdapter([](NoCopyType& p) {
+		p.v++;
+		return p.v;
+	});
+
+	EXPECT_TRUE(mutableRefAdapter);
+	EXPECT_FALSE(!mutableRefAdapter);
+	EXPECT_TRUE(!!mutableRefAdapter);
+
+	result = mutableRefAdapter(parameter);
+	EXPECT_EQ(parameter.v, SecretValue + 1);
+	EXPECT_EQ(result, SecretValue + 1);
+}
+
+TEST(HeartDynamicFunction, CopyableParameter)
+{
+	struct CopyableValue
+	{
+		int v;
+
+		CopyableValue() :
+			v(0)
+		{
+		}
+
+		CopyableValue(const CopyableValue& v) :
+			v(SecretValue)
+		{
+		}
+	};
+
+	CopyableValue parameter;
+	EXPECT_EQ(parameter.v, 0);
+
+	HeartDynamicFunction<int(CopyableValue)> adapter([](CopyableValue v) {
+		EXPECT_EQ(v.v, SecretValue);
+		return v.v;
+	});
+
+	EXPECT_TRUE(adapter);
+	EXPECT_FALSE(!adapter);
+	EXPECT_TRUE(!!adapter);
+
+	int result = adapter(parameter);
+	EXPECT_EQ(result, SecretValue);
+}
+
+TEST(HeartDynamicFunction, MoveOnlyReturnValue)
+{
+	struct MoveOnlyType
+	{
+		int v;
+
+		MoveOnlyType() :
+			v(0)
+		{
+		}
+
+		MoveOnlyType(const MoveOnlyType&) = delete;
+
+		MoveOnlyType(MoveOnlyType&& o) :
+			v(SecretValue)
+		{
+			o.v = 0;
+		}
+	};
+
+	HeartDynamicFunction<MoveOnlyType()> adapter([]() {
+		MoveOnlyType aValue;
+		EXPECT_EQ(aValue.v, 0);
+		return std::move(aValue);
+	});
+
+	EXPECT_TRUE(adapter);
+	EXPECT_FALSE(!adapter);
+	EXPECT_TRUE(!!adapter);
+
+	MoveOnlyType result = adapter();
+	EXPECT_EQ(result.v, SecretValue);
+}
+
+TEST(HeartDynamicFunction, DifferentAllocators)
+{
+	struct LargeFunctor
+	{
+		uint32_t secret = 0;
+
+		std::array<char, 512> data = {};
+
+		uint32_t operator()()
+		{
+			return secret;
+		}
+	};
+
+	struct SmallFunctor
+	{
+		uint32_t secret = 0;
+
+		std::array<char, 32> data = {};
+
+		uint32_t operator()()
+		{
+			return secret;
+		}
+	};
+
+	TestTrackingAllocator allocatorA;
+	TestTrackingAllocator allocatorB;
+
+	HeartDynamicFunction<uint32_t()> adapterA(LargeFunctor {'A'}, allocatorA);
+	HeartDynamicFunction<uint32_t()> adapterB(SmallFunctor {'B'}, allocatorB);
+
+	EXPECT_GE(allocatorA.m_allocatedCount, 1);
+	EXPECT_GE(allocatorA.m_allocatedSize, sizeof(LargeFunctor));
+	EXPECT_GE(allocatorB.m_allocatedCount, 1);
+	EXPECT_GE(allocatorB.m_allocatedSize, sizeof(SmallFunctor));
+
+	uint64_t largeSize = allocatorA.m_allocatedSize;
+	uint64_t smallSize = allocatorB.m_allocatedSize;
+
+	EXPECT_TRUE(adapterA);
+	EXPECT_EQ(adapterA(), 'A');
+	EXPECT_TRUE(adapterB);
+	EXPECT_EQ(adapterB(), 'B');
+
+	adapterA.Swap(adapterB);
+
+	EXPECT_EQ(allocatorA.m_allocatedSize, smallSize);
+	EXPECT_EQ(allocatorB.m_allocatedSize, largeSize);
+
+	EXPECT_TRUE(adapterA);
+	EXPECT_EQ(adapterA(), 'B');
+	EXPECT_TRUE(adapterB);
+	EXPECT_EQ(adapterB(), 'A');
+
+	adapterA.Clear();
+	adapterB.Clear();
+
+	EXPECT_EQ(allocatorA.m_allocatedCount, 0);
+	EXPECT_EQ(allocatorB.m_allocatedCount, 0);
+}

--- a/heart/heart-test/src/embedded_function.cpp
+++ b/heart/heart-test/src/embedded_function.cpp
@@ -1,4 +1,4 @@
-#include <heart/function.h>
+#include <heart/function/embedded_function.h>
 
 #include <heart/types.h>
 
@@ -16,9 +16,9 @@ static int StaticFunction()
 	return SecretValue;
 }
 
-TEST(HeartFunction, GlobalFunctionPointer)
+TEST(HeartEmbeddedFunction, GlobalFunctionPointer)
 {
-	HeartFunction<int()> adapter1(&VisibleFunction);
+	HeartEmbeddedFunction<int()> adapter1(&VisibleFunction);
 	EXPECT_TRUE(adapter1);
 	EXPECT_FALSE(!adapter1);
 	EXPECT_TRUE(!!adapter1);
@@ -27,9 +27,9 @@ TEST(HeartFunction, GlobalFunctionPointer)
 	EXPECT_EQ(result, SecretValue);
 }
 
-TEST(HeartFunction, StaticFunctionPointer)
+TEST(HeartEmbeddedFunction, StaticFunctionPointer)
 {
-	HeartFunction<int()> adapter1(&StaticFunction);
+	HeartEmbeddedFunction<int()> adapter1(&StaticFunction);
 	EXPECT_TRUE(adapter1);
 	EXPECT_FALSE(!adapter1);
 	EXPECT_TRUE(!!adapter1);
@@ -38,9 +38,9 @@ TEST(HeartFunction, StaticFunctionPointer)
 	EXPECT_EQ(result, SecretValue);
 }
 
-TEST(HeartFunction, SwappableToEmpty)
+TEST(HeartEmbeddedFunction, SwappableToEmpty)
 {
-	HeartFunction<int()> adapter1(&VisibleFunction);
+	HeartEmbeddedFunction<int()> adapter1(&VisibleFunction);
 	EXPECT_TRUE(adapter1);
 	EXPECT_FALSE(!adapter1);
 	EXPECT_TRUE(!!adapter1);
@@ -48,7 +48,7 @@ TEST(HeartFunction, SwappableToEmpty)
 	int result1 = adapter1();
 	EXPECT_EQ(result1, SecretValue);
 
-	HeartFunction<int()> adapter2;
+	HeartEmbeddedFunction<int()> adapter2;
 	EXPECT_FALSE(adapter2);
 	EXPECT_TRUE(!adapter2);
 	EXPECT_FALSE(!!adapter2);
@@ -65,9 +65,9 @@ TEST(HeartFunction, SwappableToEmpty)
 	EXPECT_EQ(result1, result2);
 }
 
-TEST(HeartFunction, SwappableToFull)
+TEST(HeartEmbeddedFunction, SwappableToFull)
 {
-	HeartFunction<int()> adapter1(&VisibleFunction);
+	HeartEmbeddedFunction<int()> adapter1(&VisibleFunction);
 	EXPECT_TRUE(adapter1);
 	EXPECT_FALSE(!adapter1);
 	EXPECT_TRUE(!!adapter1);
@@ -75,7 +75,7 @@ TEST(HeartFunction, SwappableToFull)
 	int result1 = adapter1();
 	EXPECT_EQ(result1, SecretValue);
 
-	HeartFunction<int()> adapter2(&VisibleFunction);
+	HeartEmbeddedFunction<int()> adapter2(&VisibleFunction);
 	EXPECT_TRUE(adapter2);
 	EXPECT_FALSE(!adapter2);
 	EXPECT_TRUE(!!adapter2);
@@ -93,7 +93,7 @@ TEST(HeartFunction, SwappableToFull)
 	EXPECT_EQ(result1, result3);
 }
 
-TEST(HeartFunction, ComplexSwap)
+TEST(HeartEmbeddedFunction, ComplexSwap)
 {
 	static int moveCount = 0;
 
@@ -120,7 +120,7 @@ TEST(HeartFunction, ComplexSwap)
 		}
 	};
 
-	HeartFunction<int()> adapter1(UncopyableFunctor {});
+	HeartEmbeddedFunction<int()> adapter1(UncopyableFunctor {});
 	EXPECT_EQ(moveCount, 1);
 	EXPECT_TRUE(adapter1);
 	EXPECT_FALSE(!adapter1);
@@ -129,7 +129,7 @@ TEST(HeartFunction, ComplexSwap)
 	int result1 = adapter1();
 	EXPECT_EQ(result1, SecretValue);
 
-	HeartFunction<int()> adapter2(UncopyableFunctor {});
+	HeartEmbeddedFunction<int()> adapter2(UncopyableFunctor {});
 	EXPECT_EQ(moveCount, 2);
 	EXPECT_TRUE(adapter1);
 	EXPECT_FALSE(!adapter1);
@@ -147,12 +147,12 @@ TEST(HeartFunction, ComplexSwap)
 	EXPECT_EQ(result3, SecretValue);
 }
 
-TEST(HeartFunction, Moveable)
+TEST(HeartEmbeddedFunction, Moveable)
 {
-	HeartFunction<int()> adapter1(&StaticFunction);
+	HeartEmbeddedFunction<int()> adapter1(&StaticFunction);
 	EXPECT_TRUE(adapter1);
 
-	HeartFunction<int()> adapter2;
+	HeartEmbeddedFunction<int()> adapter2;
 	EXPECT_FALSE(adapter2);
 
 	adapter2 = hrt::move(adapter1);
@@ -165,9 +165,9 @@ TEST(HeartFunction, Moveable)
 	EXPECT_EQ(result, SecretValue);
 }
 
-TEST(HeartFunction, CapturelessLambda)
+TEST(HeartEmbeddedFunction, CapturelessLambda)
 {
-	HeartFunction<int()> adapter([]() {
+	HeartEmbeddedFunction<int()> adapter([]() {
 		return SecretValue;
 	});
 	EXPECT_TRUE(adapter);
@@ -178,11 +178,11 @@ TEST(HeartFunction, CapturelessLambda)
 	EXPECT_EQ(result, SecretValue);
 }
 
-TEST(HeartFunction, StatefulLambda)
+TEST(HeartEmbeddedFunction, StatefulLambda)
 {
 	int theSecret = SecretValue;
 
-	HeartFunction<int()> adapter([theSecret]() {
+	HeartEmbeddedFunction<int()> adapter([theSecret]() {
 		return theSecret;
 	});
 
@@ -194,7 +194,7 @@ TEST(HeartFunction, StatefulLambda)
 	EXPECT_EQ(result, SecretValue);
 }
 
-TEST(HeartFunction, NoCopyParameter)
+TEST(HeartEmbeddedFunction, NoCopyParameter)
 {
 	struct NoCopyType
 	{
@@ -211,7 +211,7 @@ TEST(HeartFunction, NoCopyParameter)
 
 	NoCopyType parameter;
 
-	HeartFunction<int(const NoCopyType&)> constRefAdapter([](const NoCopyType& p) {
+	HeartEmbeddedFunction<int(const NoCopyType&)> constRefAdapter([](const NoCopyType& p) {
 		return p.v;
 	});
 
@@ -222,7 +222,7 @@ TEST(HeartFunction, NoCopyParameter)
 	int result = constRefAdapter(parameter);
 	EXPECT_EQ(result, SecretValue);
 
-	HeartFunction<int(NoCopyType&)> mutableRefAdapter([](NoCopyType& p) {
+	HeartEmbeddedFunction<int(NoCopyType&)> mutableRefAdapter([](NoCopyType& p) {
 		p.v++;
 		return p.v;
 	});
@@ -236,7 +236,7 @@ TEST(HeartFunction, NoCopyParameter)
 	EXPECT_EQ(result, SecretValue + 1);
 }
 
-TEST(HeartFunction, CopyableParameter)
+TEST(HeartEmbeddedFunction, CopyableParameter)
 {
 	struct CopyableValue
 	{
@@ -256,7 +256,7 @@ TEST(HeartFunction, CopyableParameter)
 	CopyableValue parameter;
 	EXPECT_EQ(parameter.v, 0);
 
-	HeartFunction<int(CopyableValue)> adapter([](CopyableValue v) {
+	HeartEmbeddedFunction<int(CopyableValue)> adapter([](CopyableValue v) {
 		EXPECT_EQ(v.v, SecretValue);
 		return v.v;
 	});
@@ -269,7 +269,7 @@ TEST(HeartFunction, CopyableParameter)
 	EXPECT_EQ(result, SecretValue);
 }
 
-TEST(HeartFunction, MoveOnlyReturnValue)
+TEST(HeartEmbeddedFunction, MoveOnlyReturnValue)
 {
 	struct MoveOnlyType
 	{
@@ -289,7 +289,7 @@ TEST(HeartFunction, MoveOnlyReturnValue)
 		}
 	};
 
-	HeartFunction<MoveOnlyType()> adapter([]() {
+	HeartEmbeddedFunction<MoveOnlyType()> adapter([]() {
 		MoveOnlyType aValue;
 		EXPECT_EQ(aValue.v, 0);
 		return std::move(aValue);
@@ -303,7 +303,7 @@ TEST(HeartFunction, MoveOnlyReturnValue)
 	EXPECT_EQ(result.v, SecretValue);
 }
 
-TEST(HeartFunction, BigStorage)
+TEST(HeartEmbeddedFunction, BigStorage)
 {
 	struct BigFunctor
 	{
@@ -317,16 +317,16 @@ TEST(HeartFunction, BigStorage)
 
 	// Ensure it (correctly) fails to compile for large storage
 #if 0
-	HeartFunction<int(), 32> adapter(BigFunctor {});
+	HeartEmbeddedFunction<int(), 32> adapter(BigFunctor {});
 #endif
 
 	// Ensure it (correctly) fails to compile for something that *seems* like it should fit
 	// This fails because it doesn't include room for the vtable
 #if 0
-	HeartFunction<int(), sizeof(BigFunctor)> adapter(BigFunctor {});
+	HeartEmbeddedFunction<int(), sizeof(BigFunctor)> adapter(BigFunctor {});
 #endif
 
-	HeartFunction<int(), 2048> bigAdapter(BigFunctor {});
+	HeartEmbeddedFunction<int(), 2048> bigAdapter(BigFunctor {});
 	EXPECT_TRUE(bigAdapter);
 
 	int result = bigAdapter();


### PR DESCRIPTION
It doesn't always make sense to use an embedded function storage for functors which can vary widely in size. Although it requires the work of dynamic allocation, it can sometimes save quite a bit of memory to pull from an allocator instead.