### PR TITLE
Allow heart without entt/rapidjson

### DIFF
--- a/heart/heart-core/include/heart/config.h
+++ b/heart/heart-core/include/heart/config.h
@@ -30,3 +30,13 @@
 #if !defined(HEART_USE_OS_FIBERS)
 #define HEART_USE_OS_FIBERS 0
 #endif
+
+// Assume we've been provided rapidjson and entt
+// If this fails, the owner is required to set these to false
+#if !defined(HEART_HAS_ENTT)
+#define HEART_HAS_ENTT 1
+#endif
+
+#if !defined(HEART_HAS_RAPIDJSON)
+#define HEART_HAS_RAPIDJSON 1
+#endif

--- a/heart/heart-core/include/heart/deserialization/deserialization.h
+++ b/heart/heart-core/include/heart/deserialization/deserialization.h
@@ -11,6 +11,7 @@
 */
 #pragma once
 
+#include <heart/config.h>
 #include <heart/debug/assert.h>
 #include <heart/types.h>
 
@@ -20,13 +21,25 @@
 
 #include <heart/stl/type_traits.h>
 
+#if HEART_HAS_ENTT
 #include <entt/core/hashed_string.hpp>
 #include <entt/meta/container.hpp>
 #include <entt/meta/factory.hpp>
 #include <entt/meta/meta.hpp>
 #include <entt/meta/resolve.hpp>
+#endif
 
+#if HEART_HAS_RAPIDJSON
 #include <rapidjson/document.h>
+#endif
+
+#if HEART_HAS_ENTT && HEART_HAS_RAPIDJSON
+#define HEART_HAS_DESERIALIZATION_SUPPORT 1
+#else
+#define HEART_HAS_DESERIALIZATION_SUPPORT 0
+#endif
+
+#if HEART_HAS_DESERIALIZATION_SUPPORT
 
 namespace entt
 {
@@ -168,3 +181,23 @@ namespace heart_priv
 #define SERIALIZE_FIELD_ALIAS(type_name, field) .data<&type_name ::field, entt::as_ref_t>(#field##_hs)
 #define SERIALIZE_FUNCTION_ALIAS(type_name, function) .func<&type_name ::function, entt::as_ref_t>(#function##_hs)
 #define END_SERIALIZE_TYPE(type_name) ;
+
+#else
+
+template <typename T1, typename T2>
+bool HeartDeserializeObject(T1& outObject, T2& node)
+{
+	return false;
+}
+
+#define BEGIN_SERIALIZE_TYPE(type_name)
+#define BEGIN_SERIALIZE_TYPE_ADDITIVE(type_name)
+#define SERIALIZE_SELF_ACCESS(type_name, setter, getter)
+#define SERIALIZE_CONVERSION(type_name, convert)
+#define SERIALIZE_FIELD(type_name, field)
+#define SERIALIZE_FUNCTION(type_name, function)
+#define SERIALIZE_FIELD_ALIAS(type_name, field)
+#define SERIALIZE_FUNCTION_ALIAS(type_name, function)
+#define END_SERIALIZE_TYPE(type_name) ;
+
+#endif

--- a/heart/heart-core/src/priv/SlimWin32.h
+++ b/heart/heart-core/src/priv/SlimWin32.h
@@ -11,6 +11,9 @@
 #define WIN32_EXTRA_LEAN
 #endif
 
+#pragma warning(push)
+#pragma warning(disable : 4005)
+
 #define NOIME
 #define NOWINRES
 #define NOGDICAPMASKS
@@ -50,11 +53,12 @@
 #define NOPROFILER
 #define NODEFERWINDOWPOS
 #define NOMCX
-#define NOIME
 #define NOPROXYSTUB
 #define NOIMAGE
 #define NO
 #define NOTAPE
 #define ANSI_ONLY
+
+#pragma warning(pop)
 
 #include <Windows.h>

--- a/heart/heart-test/src/codegen.cpp
+++ b/heart/heart-test/src/codegen.cpp
@@ -11,10 +11,14 @@
 */
 #include <heart/deserialization/deserialization.h>
 
+static_assert(HEART_HAS_DESERIALIZATION_SUPPORT == 1, "HEART_HAS_DESERIALIZATION_SUPPORT is required to run codegen test.");
+
 #include "codegen.h"
 #include "gen/gen.h"
 
 #include <rapidjson/document.h>
+
+#include <entt/meta/container.hpp>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This allows it to more easily be pulled into another project which does not need the deserialization code.